### PR TITLE
fixing compatibility with 3.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
         compile 'com.android.support:appcompat-v7:26.0.1'
         compile 'com.android.support.constraint:constraint-layout:1.0.2'
         compile 'com.android.support:support-v4:26.0.1'
-        
+        testCompile 'junit:junit:4.12'
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-
 android {
     compileSdkVersion 26
     buildToolsVersion '26.0.2'
@@ -7,9 +6,7 @@ android {
         applicationId "io.treehouses.remote"
         minSdkVersion 15
         targetSdkVersion 26
-        versionCode 2
-        versionName "2.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
     }
     buildTypes {
         release {
@@ -25,11 +22,12 @@ android {
         compile 'com.android.support:appcompat-v7:26.0.1'
         compile 'com.android.support.constraint:constraint-layout:1.0.2'
         compile 'com.android.support:support-v4:26.0.1'
-        testCompile 'junit:junit:4.12'
-        androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+        
     }
     lintOptions {
         abortOnError false
     }
 }
 
+dependencies {
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,9 @@ android {
         applicationId "io.treehouses.remote"
         minSdkVersion 15
         targetSdkVersion 26
-
+        versionCode 2
+        versionName "2.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {


### PR DESCRIPTION
When you update to 3.0.1 in the android studio it cause some gradle issues. Just needed to remove these lines.

Edit: Adding a little more info about what was fixed. If you update your android studio to the latest version, it would cause a gradel sync error if you freshly downloaded and synced it. Remove this line, it has caused the sync to pass without error.