### PR TITLE
terminal: dynamically add commands (fixes #456)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Constants.java
+++ b/app/src/main/java/io/treehouses/remote/Constants.java
@@ -50,6 +50,7 @@ public class Constants {
     public static final int REQUEST_DIALOG_FRAGMENT = 4;
     public static final int REQUEST_DIALOG_FRAGMENT_HOTSPOT = 5;
     public static final int REQUEST_DIALOG_FRAGMENT_CHPASS = 6;
+    public static final int REQUEST_DIALOG_FRAGMENT_ADD_COMMAND = 7;
 
     // Constants that indicate the current connection state (use in BluetoothChatService)
     public static final int STATE_NONE = 0;       // we're doing nothing

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
@@ -1,0 +1,72 @@
+package io.treehouses.remote.Fragments.DialogFragments;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import io.treehouses.remote.R;
+import io.treehouses.remote.pojo.CommandListItem;
+import io.treehouses.remote.utils.SaveUtils;
+
+
+public class AddCommandDialogFragment extends androidx.fragment.app.DialogFragment {
+
+    private static String TAG = "AddCommandDialogFragment";
+
+    private EditText commandTitle;
+    private EditText commandValue;
+
+    public static AddCommandDialogFragment newInstance() {
+        AddCommandDialogFragment addCommandDialogFragment = new AddCommandDialogFragment();
+        return addCommandDialogFragment;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+        View mView = inflater.inflate(R.layout.dialog_add_command,null);
+        initLayoutView(mView);
+
+        final AlertDialog mDialog = getAlertDialog(mView);
+        mDialog.setTitle(R.string.add_command_title);
+
+        return mDialog;
+    }
+
+    private AlertDialog getAlertDialog(View mView) {
+        return new AlertDialog.Builder(getActivity())
+                .setView(mView)
+                .setTitle(R.string.change_password)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setPositiveButton("Add Command", new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SaveUtils.addToCommandsList(getContext(),
+                                        new CommandListItem(commandTitle.getText().toString(), commandValue.getText().toString()));
+                                dismiss();
+                            }
+                        }
+                )
+                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dismiss();
+                    }
+                })
+                .create();
+    }
+
+    //initialize views
+    private void initLayoutView(View mView) {
+        commandTitle = mView.findViewById(R.id.commandName);
+        commandValue = mView.findViewById(R.id.commandValue);
+    }
+
+}

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
@@ -4,11 +4,15 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
 
 import io.treehouses.remote.R;
 import io.treehouses.remote.pojo.CommandListItem;
@@ -23,13 +27,11 @@ public class AddCommandDialogFragment extends androidx.fragment.app.DialogFragme
     private EditText commandValue;
 
     public static AddCommandDialogFragment newInstance() {
-        AddCommandDialogFragment addCommandDialogFragment = new AddCommandDialogFragment();
-        return addCommandDialogFragment;
+        return new AddCommandDialogFragment();
     }
 
-    @Override
+    @Override @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View mView = inflater.inflate(R.layout.dialog_add_command,null);
         initLayoutView(mView);
@@ -48,9 +50,15 @@ public class AddCommandDialogFragment extends androidx.fragment.app.DialogFragme
                 .setPositiveButton("Add Command", new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                SaveUtils.addToCommandsList(getContext(),
-                                        new CommandListItem(commandTitle.getText().toString(), commandValue.getText().toString()));
-                                dismiss();
+                                if (commandTitle.getText().toString().length() > 0 && commandValue.getText().toString().length() > 0) {
+                                    SaveUtils.addToCommandsList(getContext(),
+                                            new CommandListItem(commandTitle.getText().toString(), commandValue.getText().toString()));
+                                    done();
+                                    dismiss();
+                                }
+                                else {
+                                    Toast.makeText(getContext(), "Please Enter Text", Toast.LENGTH_LONG).show();
+                                }
                             }
                         }
                 )
@@ -59,8 +67,13 @@ public class AddCommandDialogFragment extends androidx.fragment.app.DialogFragme
                     public void onClick(DialogInterface dialog, int which) {
                         dismiss();
                     }
-                })
-                .create();
+                }).create();
+    }
+
+    private void done() {
+        Intent intent = new Intent();
+        intent.putExtra("done",true);
+        getTargetFragment().onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, intent);
     }
 
     //initialize views

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ChPasswordDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ChPasswordDialogFragment.java
@@ -26,7 +26,7 @@ public class ChPasswordDialogFragment extends androidx.fragment.app.DialogFragme
     private EditText confirmPassEditText;
     private TextBoxValidation textBoxValidation = new TextBoxValidation();
 
-    public static ChPasswordDialogFragment newInstance(int num) {
+    public static ChPasswordDialogFragment newInstance() {
         ChPasswordDialogFragment chPassDialogFragment = new ChPasswordDialogFragment();
         return chPassDialogFragment;
     }

--- a/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
@@ -6,6 +6,7 @@ import io.treehouses.remote.Constants;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.bases.BaseFragment;
+import io.treehouses.remote.utils.SaveUtils;
 
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -68,6 +69,8 @@ public class StatusFragment extends BaseFragment {
         String ping = "treehouses detectrpi";
         byte[] pSend1 = ping.getBytes();
         mChatService.write(pSend1);
+        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_TITLES_KEY);
+        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_VALUES_KEY);
         return view;
     }
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
@@ -69,8 +69,6 @@ public class StatusFragment extends BaseFragment {
         String ping = "treehouses detectrpi";
         byte[] pSend1 = ping.getBytes();
         mChatService.write(pSend1);
-        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_TITLES_KEY);
-        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_VALUES_KEY);
         return view;
     }
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
@@ -69,6 +69,8 @@ public class StatusFragment extends BaseFragment {
         String ping = "treehouses detectrpi";
         byte[] pSend1 = ping.getBytes();
         mChatService.write(pSend1);
+        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_TITLES_KEY);
+        SaveUtils.clearArrayList(getContext(), SaveUtils.COMMANDS_VALUES_KEY);
         return view;
     }
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import io.treehouses.remote.Constants;
+import io.treehouses.remote.Fragments.DialogFragments.AddCommandDialogFragment;
 import io.treehouses.remote.Fragments.DialogFragments.ChPasswordDialogFragment;
 import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
@@ -103,6 +104,7 @@ public class TerminalFragment extends BaseTerminalFragment {
                 }
             } else {
                 //TODO: ADD NEW COMMAND HERE
+                showAddCommandDialog();
             }
 
             return false;
@@ -278,6 +280,11 @@ public class TerminalFragment extends BaseTerminalFragment {
         androidx.fragment.app.DialogFragment dialogFrag = ChPasswordDialogFragment.newInstance(123);
         dialogFrag.setTargetFragment(this, Constants.REQUEST_DIALOG_FRAGMENT_CHPASS);
         dialogFrag.show(getFragmentManager().beginTransaction(), "ChangePassDialog");
+    }
+
+    private void showAddCommandDialog() {
+        androidx.fragment.app.DialogFragment dialogFragment = AddCommandDialogFragment.newInstance();
+        dialogFragment.show(getFragmentManager().beginTransaction(), "AddCommandDialog");
     }
 
     private void addToCommandList(String writeMessage) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -47,6 +47,7 @@ public class TerminalFragment extends BaseTerminalFragment {
     private int i;
     private String last;
     View view;
+    HashMap<String, List<CommandListItem>> expandableListDetail;
 
     public TerminalFragment() {
     }
@@ -57,6 +58,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         mChatService = listener.getChatService();
         mChatService.updateHandler(mHandler);
         instance = this;
+        expandableListDetail = getCommandsList();
         Log.e("TERMINAL mChatService", "" + mChatService.getState());
         setHasOptionsMenu(true);
         setupList();
@@ -64,7 +66,7 @@ public class TerminalFragment extends BaseTerminalFragment {
     }
 
     public HashMap<String, List<CommandListItem>> getCommandsList() {
-        HashMap<String, List<CommandListItem>> expandableListDetail = new HashMap<String, List<CommandListItem>>();
+        expandableListDetail = new HashMap<String, List<CommandListItem>>();
         List<CommandListItem> commands = new ArrayList<>();
         commands.add(new CommandListItem("CHANGE PASSWORD", ""));
         commands.add(new CommandListItem("HELP", "treehouses help"));
@@ -83,18 +85,23 @@ public class TerminalFragment extends BaseTerminalFragment {
 
     public void setupList() {
         expandableListView = view.findViewById(R.id.terminalList);
-        final HashMap<String, List<CommandListItem>> expandableListDetail = getCommandsList();
         List<String> expandableListTitle = new ArrayList<>(expandableListDetail.keySet());
         ExpandableListAdapter expandableListAdapter = new CommandListAdapter(getContext(), expandableListTitle, expandableListDetail);
         expandableListView.setAdapter(expandableListAdapter);
         expandableListView.setOnChildClickListener((parent, v, groupPosition, childPosition, id) -> {
-            String title = expandableListDetail.get(expandableListTitle.get(groupPosition)).get(childPosition).getTitle();
-            if (title.equalsIgnoreCase("CLEAR")) {
-                MainApplication.getTerminalList().clear();
-                getmConversationArrayAdapter().notifyDataSetChanged();
-            } else if (title.equalsIgnoreCase("CHANGE PASSWORD")) {
-                showChPasswordDialog();
-            } else listener.sendMessage(expandableListDetail.get(expandableListTitle.get(groupPosition)).get(childPosition).getCommand());
+            if (childPosition < expandableListDetail.get("Commands").size()) {
+                String title = expandableListDetail.get(expandableListTitle.get(groupPosition)).get(childPosition).getTitle();
+                if (title.equalsIgnoreCase("CLEAR")) {
+                    MainApplication.getTerminalList().clear();
+                    getmConversationArrayAdapter().notifyDataSetChanged();
+                } else if (title.equalsIgnoreCase("CHANGE PASSWORD")) {
+                    showChPasswordDialog();
+                } else {
+                    listener.sendMessage(expandableListDetail.get(expandableListTitle.get(groupPosition)).get(childPosition).getCommand());
+                }
+            } else {
+                //TODO: ADD NEW COMMAND HERE
+            }
 
             return false;
         });

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -33,6 +33,7 @@ import io.treehouses.remote.R;
 import io.treehouses.remote.adapter.CommandListAdapter;
 import io.treehouses.remote.bases.BaseTerminalFragment;
 import io.treehouses.remote.pojo.CommandListItem;
+import io.treehouses.remote.utils.SaveUtils;
 
 public class TerminalFragment extends BaseTerminalFragment {
 
@@ -58,30 +59,31 @@ public class TerminalFragment extends BaseTerminalFragment {
         mChatService = listener.getChatService();
         mChatService.updateHandler(mHandler);
         instance = this;
-        expandableListDetail = getCommandsList();
+        expandableListDetail = new HashMap<>();
+        expandableListDetail.put("Commands", SaveUtils.getCommandsList(getContext()));
         Log.e("TERMINAL mChatService", "" + mChatService.getState());
         setHasOptionsMenu(true);
         setupList();
         return view;
     }
 
-    public HashMap<String, List<CommandListItem>> getCommandsList() {
-        expandableListDetail = new HashMap<String, List<CommandListItem>>();
-        List<CommandListItem> commands = new ArrayList<>();
-        commands.add(new CommandListItem("CHANGE PASSWORD", ""));
-        commands.add(new CommandListItem("HELP", "treehouses help"));
-        commands.add(new CommandListItem("DOCKER PS", "docker ps"));
-        commands.add(new CommandListItem("DETECT RPI", "treehouses detectrpi"));
-        commands.add(new CommandListItem("EXPAND FS", "treehouses expandfs"));
-        commands.add(new CommandListItem("VNC ON", "treehouses vnc on"));
-        commands.add(new CommandListItem("VNC OFF", "treehouses vnc off"));
-        commands.add(new CommandListItem("VNC STATUS", "treehouses vnc"));
-        commands.add(new CommandListItem("TOR", "treehouses tor"));
-        commands.add(new CommandListItem("NETWORK MODE INFO", "treehouses networkmode info"));
-        commands.add(new CommandListItem("CLEAR", ""));
-        expandableListDetail.put("Commands", commands);
-        return expandableListDetail;
-    }
+//    public HashMap<String, List<CommandListItem>> getCommandsList() {
+//        expandableListDetail = new HashMap<String, List<CommandListItem>>();
+//        List<CommandListItem> commands = new ArrayList<>();
+//        commands.add(new CommandListItem("CHANGE PASSWORD", ""));
+//        commands.add(new CommandListItem("HELP", "treehouses help"));
+//        commands.add(new CommandListItem("DOCKER PS", "docker ps"));
+//        commands.add(new CommandListItem("DETECT RPI", "treehouses detectrpi"));
+//        commands.add(new CommandListItem("EXPAND FS", "treehouses expandfs"));
+//        commands.add(new CommandListItem("VNC ON", "treehouses vnc on"));
+//        commands.add(new CommandListItem("VNC OFF", "treehouses vnc off"));
+//        commands.add(new CommandListItem("VNC STATUS", "treehouses vnc"));
+//        commands.add(new CommandListItem("TOR", "treehouses tor"));
+//        commands.add(new CommandListItem("NETWORK MODE INFO", "treehouses networkmode info"));
+//        commands.add(new CommandListItem("CLEAR", ""));
+//        expandableListDetail.put("Commands", commands);
+//        return expandableListDetail;
+//    }
 
     public void setupList() {
         expandableListView = view.findViewById(R.id.terminalList);

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -83,12 +83,12 @@ public class TerminalFragment extends BaseTerminalFragment {
                     MainApplication.getTerminalList().clear();
                     getmConversationArrayAdapter().notifyDataSetChanged();
                 } else if (title.equalsIgnoreCase("CHANGE PASSWORD")) {
-                    showChPasswordDialog();
+                    showDialog(ChPasswordDialogFragment.newInstance(), Constants.REQUEST_DIALOG_FRAGMENT_CHPASS, "ChangePassDialog");
                 } else {
                     listener.sendMessage(expandableListDetail.get(expandableListTitle.get(groupPosition)).get(childPosition).getCommand());
                 }
             } else {
-                showAddCommandDialog();
+                showDialog(AddCommandDialogFragment.newInstance(), Constants.REQUEST_DIALOG_FRAGMENT_ADD_COMMAND, "AddCommandDialog");
             }
 
             return false;
@@ -142,13 +142,9 @@ public class TerminalFragment extends BaseTerminalFragment {
         setupChat();
     }
 
-    public static TerminalFragment getInstance() {
-        return instance;
-    }
+    public static TerminalFragment getInstance() { return instance; }
 
-    public ArrayAdapter<String> getmConversationArrayAdapter() {
-        return mConversationArrayAdapter;
-    }
+    public ArrayAdapter<String> getmConversationArrayAdapter() { return mConversationArrayAdapter; }
 
     /**
      * Set up the UI and background operations for chat.
@@ -173,9 +169,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         btnSendClickListener();
 
         // Initialize the BluetoothChatService to perform bluetooth connections
-        if (mChatService.getState() == Constants.STATE_NONE) {
-            mChatService = new BluetoothChatService(mHandler);
-        }
+        if (mChatService.getState() == Constants.STATE_NONE) mChatService = new BluetoothChatService(mHandler);
     }
 
     private void btnSendClickListener() {
@@ -200,9 +194,7 @@ public class TerminalFragment extends BaseTerminalFragment {
             last = list.get(--i);
             mOutEditText.setText(last);
             mOutEditText.setSelection(mOutEditText.length());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        } catch (Exception e) { e.printStackTrace(); }
     }
 
     /**
@@ -244,8 +236,6 @@ public class TerminalFragment extends BaseTerminalFragment {
             Log.d(TAG, "back from change password");
             //send password to command line interface
             listener.sendMessage(password);
-        } else {
-            Log.d(TAG, "back from change password, fail");
         }
     }
 
@@ -272,17 +262,10 @@ public class TerminalFragment extends BaseTerminalFragment {
         }
     }
 
-    public void showChPasswordDialog() {
+    public void showDialog(androidx.fragment.app.DialogFragment dialogFrag, int requestCode, String tag) {
         // Create an instance of the dialog fragment and show it
-        androidx.fragment.app.DialogFragment dialogFrag = ChPasswordDialogFragment.newInstance(123);
-        dialogFrag.setTargetFragment(this, Constants.REQUEST_DIALOG_FRAGMENT_CHPASS);
-        dialogFrag.show(getFragmentManager().beginTransaction(), "ChangePassDialog");
-    }
-
-    private void showAddCommandDialog() {
-        androidx.fragment.app.DialogFragment dialogFragment = AddCommandDialogFragment.newInstance();
-        dialogFragment.setTargetFragment(this, Constants.REQUEST_DIALOG_FRAGMENT_ADD_COMMAND);
-        dialogFragment.show(getFragmentManager().beginTransaction(), "AddCommandDialog");
+        dialogFrag.setTargetFragment(this, requestCode);
+        dialogFrag.show(getFragmentManager().beginTransaction(), tag);
     }
 
     private void addToCommandList(String writeMessage) {

--- a/app/src/main/java/io/treehouses/remote/MainApplication.java
+++ b/app/src/main/java/io/treehouses/remote/MainApplication.java
@@ -3,6 +3,8 @@ package io.treehouses.remote;
 import android.app.Application;
 import java.util.ArrayList;
 
+import io.treehouses.remote.utils.SaveUtils;
+
 public class MainApplication extends Application {
 
     private static ArrayList terminalList, tunnelList, commandList;
@@ -13,6 +15,7 @@ public class MainApplication extends Application {
         terminalList = new ArrayList();
         tunnelList = new ArrayList();
         commandList = new ArrayList();
+        SaveUtils.initCommandsList(getApplicationContext());
     }
 
     public static ArrayList getTerminalList() {

--- a/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.java
@@ -1,6 +1,7 @@
 package io.treehouses.remote.adapter;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,8 +29,10 @@ public class CommandListAdapter extends BaseExpandableListAdapter {
 
     @Override
     public Object getChild(int listPosition, int expandedListPosition) {
-        return this.expandableListDetail.get(this.expandableListTitle.get(listPosition))
-                .get(expandedListPosition).getTitle();
+        if (expandedListPosition < expandableListDetail.get(this.expandableListTitle.get(listPosition)).size()) {
+            return this.expandableListDetail.get(this.expandableListTitle.get(listPosition)).get(expandedListPosition).getTitle();
+        }
+        return "Add";
     }
 
     @Override
@@ -40,18 +43,23 @@ public class CommandListAdapter extends BaseExpandableListAdapter {
     @Override
     public View getChildView(int listPosition, final int expandedListPosition, boolean isLastChild, View convertView, ViewGroup parent) {
         final String expandedListText = (String) getChild(listPosition, expandedListPosition);
-        if (convertView == null) {
-            convertView = getConvertView(R.layout.list_item);
+        if (expandedListPosition == this.expandableListDetail.get(this.expandableListTitle.get(listPosition)).size()) {
+            convertView = getConvertView(R.layout.list_add);
         }
-        TextView expandedListTextView = convertView.findViewById(R.id.expandedListItem);
-        expandedListTextView.setText(expandedListText);
+        else {
+            convertView = getConvertView(R.layout.list_item);
+            TextView expandedListTextView = convertView.findViewById(R.id.expandedListItem);
+            expandedListTextView.setText(expandedListText);
+        }
         return convertView;
     }
 
     @Override
     public int getChildrenCount(int listPosition) {
-        return this.expandableListDetail.get(this.expandableListTitle.get(listPosition))
-                .size();
+        if (listPosition == 0) {
+            return this.expandableListDetail.get(this.expandableListTitle.get(listPosition)).size() + 1;
+        }
+        return this.expandableListDetail.get(this.expandableListTitle.get(listPosition)).size();
     }
 
     @Override

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -14,8 +14,8 @@ import io.treehouses.remote.pojo.CommandListItem;
 public class SaveUtils {
     private static final String DELIMITER = "#/@/#";
 
-    private static final String COMMANDS_TITLES_KEY = "commands_titles";
-    private static final String COMMANDS_VALUES_KEY = "commands_values";
+    public static final String COMMANDS_TITLES_KEY = "commands_titles";
+    public static final String COMMANDS_VALUES_KEY = "commands_values";
 
     public static void saveStringArray(Context context, ArrayList<String> array, String arrayName) {
         String strArr = "";
@@ -23,7 +23,7 @@ public class SaveUtils {
             strArr += array.get(i) + DELIMITER;
         }
         if (strArr.length() != 0) {
-            strArr = strArr.substring(0, strArr.length() - 1);
+            strArr = strArr.substring(0, strArr.length() - DELIMITER.length());
         }
 
         SharedPreferences.Editor e = PreferenceManager.getDefaultSharedPreferences(context).edit();
@@ -44,14 +44,11 @@ public class SaveUtils {
         return new ArrayList<>(Arrays.asList(strArr));
     }
 
-    public static Boolean addToArrayList(Context context, String arrayName, String toAdd) {
+    public static void addToArrayList(Context context, String arrayName, String toAdd) {
         ArrayList<String> arrayList = getStringArray(context, arrayName);
-        if (arrayList != null) {
-            arrayList.add(toAdd);
-            saveStringArray(context, arrayList, arrayName);
-            return true;
-        }
-        return false;
+        if (arrayList == null) arrayList = new ArrayList<>();
+        arrayList.add(toAdd);
+        saveStringArray(context, arrayList, arrayName);
     }
 
     public static Boolean removeFromArrayList(Context context, String arrayName, String toRemove) {
@@ -61,6 +58,10 @@ public class SaveUtils {
             return true;
         }
         return false;
+    }
+
+    public static void clearArrayList(Context context, String arrayName) {
+        saveStringArray(context, new ArrayList<>(), arrayName);
     }
 
     //TERMINAL COMMAND LIST UTILS
@@ -84,7 +85,8 @@ public class SaveUtils {
         List<CommandListItem> finalArray = new ArrayList<>();
 
         if (titles == null || values == null || titles.size() != values.size()) {
-            Log.e("COMMANDLIST", "ERROR SIZE: COMMANDS: " + titles.size() +" and VALUES: " + values.size());
+            Log.e("COMMANDLIST", "ERROR SIZE: COMMANDS and VALUES");
+            return new ArrayList<CommandListItem>();
         }
         for (int i = 0; i < titles.size(); i++) {
             finalArray.add(new CommandListItem(titles.get(i), values.get(i)));

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,6 +18,8 @@ public class SaveUtils {
 
     public static final String COMMANDS_TITLES_KEY = "commands_titles";
     public static final String COMMANDS_VALUES_KEY = "commands_values";
+
+    public static final String ACTION_KEYWORD = "ACTION";
 
     public static void saveStringArray(Context context, ArrayList<String> array, String arrayName) {
         String strArr = "";
@@ -36,7 +40,7 @@ public class SaveUtils {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String str = prefs.getString(arrayName, null);
         if (str == null || str.equals("")) {
-            return null;
+            return new ArrayList<String>();
         }
         else {
             strArr = str.split(DELIMITER);
@@ -46,14 +50,13 @@ public class SaveUtils {
 
     public static void addToArrayList(Context context, String arrayName, String toAdd) {
         ArrayList<String> arrayList = getStringArray(context, arrayName);
-        if (arrayList == null) arrayList = new ArrayList<>();
         arrayList.add(toAdd);
         saveStringArray(context, arrayList, arrayName);
     }
 
     public static Boolean removeFromArrayList(Context context, String arrayName, String toRemove) {
         ArrayList<String> arrayList = getStringArray(context, arrayName);
-        if (arrayList != null) {
+        if (!arrayList.isEmpty()) {
             arrayList.remove(toRemove);
             return true;
         }
@@ -67,7 +70,7 @@ public class SaveUtils {
     //TERMINAL COMMAND LIST UTILS
 
     public static void initCommandsList(Context context) {
-        if (getStringArray(context, COMMANDS_TITLES_KEY) == null || getStringArray(context, COMMANDS_VALUES_KEY) == null) {
+        if (getStringArray(context, COMMANDS_TITLES_KEY).isEmpty() || getStringArray(context, COMMANDS_VALUES_KEY).isEmpty()) {
             String[] titles = {"CHANGE PASSWORD", "HELP", "DOCKER PS", "DETECT RPI", "EXPAND FS",
                     "VNC ON", "VNC OFF", "VNC STATUS", "TOR", "NETWORK MODE INFO", "CLEAR"};
             String[] commands = {"ACTION", "treehouses help", "docker ps", "treehouses detectrpi", "treehouses expandfs",
@@ -84,10 +87,14 @@ public class SaveUtils {
 
         List<CommandListItem> finalArray = new ArrayList<>();
 
-        if (titles == null || values == null || titles.size() != values.size()) {
-            Log.e("COMMANDLIST", "ERROR SIZE: COMMANDS and VALUES");
+        if (titles.isEmpty() || values.isEmpty()) {
             return new ArrayList<CommandListItem>();
         }
+        if (titles.size() != values.size()) {
+            Log.e("COMMANDLIST", "ERROR SIZE: COMMANDS and VALUES");
+            return new ArrayList<>();
+        }
+
         for (int i = 0; i < titles.size(); i++) {
             finalArray.add(new CommandListItem(titles.get(i), values.get(i)));
         }

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -1,0 +1,118 @@
+package io.treehouses.remote.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.treehouses.remote.pojo.CommandListItem;
+
+public class SaveUtils {
+    private static final String DELIMITER = "#/@/#";
+
+    private static final String COMMANDS_TITLES_KEY = "commands_titles";
+    private static final String COMMANDS_VALUES_KEY = "commands_values";
+
+    public static void saveStringArray(Context context, ArrayList<String> array, String arrayName) {
+        String strArr = "";
+        for (int i=0; i<array.size(); i++) {
+            strArr += array.get(i) + DELIMITER;
+        }
+        if (strArr.length() != 0) {
+            strArr = strArr.substring(0, strArr.length() - 1);
+        }
+
+        SharedPreferences.Editor e = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        e.putString(arrayName, strArr);
+        e.commit();
+    }
+
+    public static ArrayList<String> getStringArray(Context context, String arrayName) {
+        String[] strArr;
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String str = prefs.getString(arrayName, null);
+        if (str == null || str.equals("")) {
+            return null;
+        }
+        else {
+            strArr = str.split(DELIMITER);
+        }
+        return new ArrayList<>(Arrays.asList(strArr));
+    }
+
+    public static Boolean addToArrayList(Context context, String arrayName, String toAdd) {
+        ArrayList<String> arrayList = getStringArray(context, arrayName);
+        if (arrayList != null) {
+            arrayList.add(toAdd);
+            saveStringArray(context, arrayList, arrayName);
+            return true;
+        }
+        return false;
+    }
+
+    public static Boolean removeFromArrayList(Context context, String arrayName, String toRemove) {
+        ArrayList<String> arrayList = getStringArray(context, arrayName);
+        if (arrayList != null) {
+            arrayList.remove(toRemove);
+            return true;
+        }
+        return false;
+    }
+
+    //TERMINAL COMMAND LIST UTILS
+
+    public static void initCommandsList(Context context) {
+        if (getStringArray(context, COMMANDS_TITLES_KEY) == null || getStringArray(context, COMMANDS_VALUES_KEY) == null) {
+            String[] titles = {"CHANGE PASSWORD", "HELP", "DOCKER PS", "DETECT RPI", "EXPAND FS",
+                    "VNC ON", "VNC OFF", "VNC STATUS", "TOR", "NETWORK MODE INFO", "CLEAR"};
+            String[] commands = {"ACTION", "treehouses help", "docker ps", "treehouses detectrpi", "treehouses expandfs",
+                    "treehouses vnc on", "treehouses vnc off", "treehouses vnc", "treehouses tor", "treehouses networkmode info", "ACTION"};
+
+            saveStringArray(context, new ArrayList<>(Arrays.asList(titles)), COMMANDS_TITLES_KEY);
+            saveStringArray(context, new ArrayList<>(Arrays.asList(commands)), COMMANDS_VALUES_KEY);
+        }
+    }
+
+    public static List<CommandListItem> getCommandsList(Context context) {
+        ArrayList<String> titles = getStringArray(context, COMMANDS_TITLES_KEY);
+        ArrayList<String> values = getStringArray(context, COMMANDS_VALUES_KEY);
+
+        List<CommandListItem> finalArray = new ArrayList<>();
+
+        if (titles == null || values == null || titles.size() != values.size()) {
+            Log.e("COMMANDLIST", "ERROR SIZE: COMMANDS: " + titles.size() +" and VALUES: " + values.size());
+        }
+        for (int i = 0; i < titles.size(); i++) {
+            finalArray.add(new CommandListItem(titles.get(i), values.get(i)));
+        }
+        return finalArray;
+    }
+
+    public static void saveCommandsList(Context context, List<CommandListItem> newCommandList) {
+        ArrayList<String> titles = new ArrayList<>();
+        ArrayList<String> commands = new ArrayList<>();
+
+        for (CommandListItem commandListItem : newCommandList) {
+            titles.add(commandListItem.getTitle());
+            commands.add(commandListItem.getCommand());
+        }
+
+        saveStringArray(context, titles, COMMANDS_TITLES_KEY);
+        saveStringArray(context, commands, COMMANDS_VALUES_KEY);
+
+    }
+
+    public static void addToCommandsList(Context context, CommandListItem commandListItem) {
+        addToArrayList(context, COMMANDS_TITLES_KEY, commandListItem.getTitle());
+        addToArrayList(context, COMMANDS_VALUES_KEY, commandListItem.getCommand());
+    }
+
+    public static void removeFromCommandsList(Context context, CommandListItem commandListItem) {
+        removeFromArrayList(context, COMMANDS_TITLES_KEY, commandListItem.getTitle());
+        removeFromArrayList(context, COMMANDS_VALUES_KEY, commandListItem.getCommand());
+    }
+}

--- a/app/src/main/res/drawable/add_command_background.xml
+++ b/app/src/main/res/drawable/add_command_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/md_light_green_50"            android:state_pressed="true"/>
+    <item android:drawable="@color/md_light_green_100" android:state_focused="true"/>
+    <item android:drawable="@color/md_green_100"/>
+</selector>

--- a/app/src/main/res/drawable/ic_add_box_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_box_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#585858"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_terminal_fragment.xml
+++ b/app/src/main/res/layout/activity_terminal_fragment.xml
@@ -110,6 +110,7 @@
             android:layout_marginLeft="@dimen/margin_large"
             android:layout_marginEnd="@dimen/margin_medium"
             android:layout_marginRight="@dimen/margin_medium"
+            android:layout_marginBottom="100dp"
             android:background="@color/bg_white"
             android:descendantFocusability="beforeDescendants"
             android:divider="@android:color/transparent"

--- a/app/src/main/res/layout/dialog_add_command.xml
+++ b/app/src/main/res/layout/dialog_add_command.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/commandName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:ems="10"
+        android:layout_marginStart="@dimen/margin_huge"
+        android:layout_marginEnd="@dimen/margin_huge"
+        android:background="@drawable/rectangle_border"
+        android:inputType="textPersonName"
+        android:padding="5dp"
+        android:hint="Title" />
+
+    <EditText
+        android:id="@+id/commandValue"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:layout_marginEnd="@dimen/margin_huge"
+        android:layout_marginStart="@dimen/margin_huge"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:background="@drawable/rectangle_border"
+        android:padding="5dp"
+        android:inputType="textPersonName"
+        android:hint="Command e.g treehouses detectrpi" />
+</LinearLayout>

--- a/app/src/main/res/layout/list_add.xml
+++ b/app/src/main/res/layout/list_add.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="@color/md_green_50">
+    android:background="@drawable/add_command_background">
 
     <ImageView
         android:id="@+id/expandedListItem"

--- a/app/src/main/res/layout/list_add.xml
+++ b/app/src/main/res/layout/list_add.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@color/md_green_50">
+
+    <ImageView
+        android:id="@+id/expandedListItem"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:background="@drawable/ic_add_box_black_24dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:scaleType="center" />
+</LinearLayout>

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -11,7 +11,7 @@
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
         android:textAlignment="center"
-        android:textSize="12sp"
+        android:textSize="14sp"
         android:textColor="@color/md_white_1000"
         android:background="@drawable/ripple" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,4 +130,7 @@
     <string name="test_connection_message">You should be able to see a flashing green light on your Raspberry Pi right now.</string>
     <string name="test_finished">The flashing has now stopped.</string>
 
+    <!--Add Command Dialog-->
+    <string name="add_command_title">Add a Command</string>
+
 </resources>


### PR DESCRIPTION
# Fixes Issue: #456 
Added the ability to add custom commands to the dropdown menu in Terminal. Utilizes SharedPreferences to store an array of commands.
## Possible Improvements
Ability to reset to default: Needs a settings screen for implementation

## Screenshots
<img width="441" alt="Screen Shot 2019-11-26 at 11 27 10 PM" src="https://user-images.githubusercontent.com/37857112/69693730-6eee1880-10a4-11ea-81f8-4c88475c3066.png">
<img width="439" alt="Screen Shot 2019-11-26 at 11 27 28 PM" src="https://user-images.githubusercontent.com/37857112/69693729-6eee1880-10a4-11ea-855f-3f4a7bee2b86.png">
<img width="439" alt="Screen Shot 2019-11-26 at 11 27 57 PM" src="https://user-images.githubusercontent.com/37857112/69693728-6eee1880-10a4-11ea-9615-c181ea3b3427.png">
