### PR TITLE
settings: add clear and default commands list (fixes #524)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
@@ -1,16 +1,22 @@
 package io.treehouses.remote.Fragments;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import io.treehouses.remote.R;
 import io.treehouses.remote.bases.BaseFragment;
+import io.treehouses.remote.utils.SaveUtils;
 
-public class SettingsFragment extends PreferenceFragmentCompat {
+public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceClickListener {
     public SettingsFragment() {
 
     }
@@ -22,5 +28,30 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.app_preferences, rootKey);
+        Preference clearCommandsList = findPreference("clear_commands");
+        Preference resetCommandsList = findPreference("reset_commands");
+        if (clearCommandsList != null && resetCommandsList != null) {
+            clearCommandsList.setOnPreferenceClickListener(this);
+            resetCommandsList.setOnPreferenceClickListener(this);
+        }
+        else {
+            Log.e("Settings Fragment", "Null Preference");
+        }
+    }
+
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        switch (preference.getKey()) {
+            case "clear_commands":
+                SaveUtils.clearCommandsList(getContext());
+                Toast.makeText(getContext(), "Commands List has been Cleared", Toast.LENGTH_LONG).show();
+                break;
+            case "reset_commands":
+                SaveUtils.clearCommandsList(getContext());
+                SaveUtils.initCommandsList(getContext());
+                Toast.makeText(getContext(), "Commands has been reset to default", Toast.LENGTH_LONG).show();
+                break;
+        }
+        return false;
     }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -2,6 +2,7 @@ package io.treehouses.remote.bases;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Message;
@@ -16,6 +17,8 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.preference.PreferenceManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -147,22 +150,29 @@ public class BaseTerminalFragment extends BaseFragment{
         return true;
     }
     public void setUpAutoComplete(AutoCompleteTextView autoComplete) {
-        final String[] commands = getResources().getStringArray(R.array.commands_list);
-        final String[] array2 = {"treehouses", "docker"};
-        ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, commands);
-        ArrayAdapter<String> arrayAdapter1 = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, array2);
-        autoComplete.setThreshold(1);
-        autoComplete.setAdapter(arrayAdapter);
-        autoComplete.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if (s.length() < 6) { autoComplete.setAdapter(arrayAdapter1); }
-                else { autoComplete.setAdapter(arrayAdapter); }
-            }
-            @Override
-            public void afterTextChanged(Editable s) { }
-        });
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+
+        if (preferences.getBoolean("autocomplete", true)) {
+            final String[] commands = getResources().getStringArray(R.array.commands_list);
+            final String[] array2 = {"treehouses", "docker"};
+            ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, commands);
+            ArrayAdapter<String> arrayAdapter1 = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, array2);
+            autoComplete.setThreshold(1);
+            autoComplete.setAdapter(arrayAdapter);
+            autoComplete.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                    if (s.length() < 6) autoComplete.setAdapter(arrayAdapter1);
+                    else autoComplete.setAdapter(arrayAdapter);
+                }
+                @Override
+                public void afterTextChanged(Editable s) {
+                }
+            });
+        }
     }
 }

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -124,4 +124,9 @@ public class SaveUtils {
         removeFromArrayList(context, COMMANDS_TITLES_KEY, commandListItem.getTitle());
         removeFromArrayList(context, COMMANDS_VALUES_KEY, commandListItem.getCommand());
     }
+
+    public static void clearCommandsList (Context context) {
+        clearArrayList(context, COMMANDS_TITLES_KEY);
+        clearArrayList(context, COMMANDS_VALUES_KEY);
+    }
 }

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -4,6 +4,16 @@
             android:title="Splash Screen"
             android:key="splashScreen"
             android:defaultValue="true"/>
+        <Preference
+            android:title="Clear Commands List"
+            android:key="clear_commands"
+            android:summary="Clear the customizable commands list in terminal">
+        </Preference>
+        <Preference
+            android:title="Default Commands List"
+            android:key="reset_commands"
+            android:summary="Reset list to the default commands in terminal">
+        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="About">

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -4,6 +4,11 @@
             android:title="Splash Screen"
             android:key="splashScreen"
             android:defaultValue="true"/>
+        <CheckBoxPreference
+            android:title="Terminal Autocomplete"
+            android:key="autocomplete"
+            android:defaultValue="true" />
+
         <Preference
             android:title="Clear Commands List"
             android:key="clear_commands"


### PR DESCRIPTION
# Fixes #524 
## Features
Added "reset to default" and "clear commands list" to the settings screen. 

- Reset to default: Resets the commands list to the default values
- Clear Commands List: Makes commands list empty

Added the option to toggle autocomplete.
- Terminal Autocomplete: Turning it off disables autocomplete in the terminal
## Screenshot(s)
<img width="441" alt="Screen Shot 2019-12-04 at 7 56 02 PM" src="https://user-images.githubusercontent.com/37857112/70194471-847cc700-16d0-11ea-8710-cd5af93fa864.png">


