### PR TITLE
network: no null pointer crash (fixes #572)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/utils/TextWatcherUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/TextWatcherUtils.java
@@ -84,7 +84,10 @@ public class TextWatcherUtils extends ViewHolderBridge implements android.text.T
     }
 
     private Boolean viewCondition(TextInputEditText editText, Editable editable) {
-        return editable == editText.getEditableText() && !messageSent;
+        if (editText != null && editable != null) {
+            return editable == editText.getEditableText() && !messageSent;
+        }
+        return false;
     }
 
     private Boolean length(EditText editText) {


### PR DESCRIPTION
# Fixes #572 
Add check for null.
```
if (editText != null && editable != null) {
            return editable == editText.getEditableText() && !messageSent;
        }
        return false;
```