### PR TITLE
refactor: remove unused imports (fixes #578)

### DIFF
--- a/app/src/androidTest/java/io/treehouses/remote/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/io/treehouses/remote/ExampleInstrumentedTest.java
@@ -2,13 +2,13 @@ package io.treehouses.remote;
 
 import android.content.Context;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import androidx.test.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Instrumentation test, which will execute on an Android device.

--- a/app/src/main/java/io/treehouses/remote/Constants.java
+++ b/app/src/main/java/io/treehouses/remote/Constants.java
@@ -22,17 +22,9 @@ package io.treehouses.remote;
  * Created by yubo on 7/11/17.
  */
 
-import android.os.Bundle;
-import android.os.PersistableBundle;
-import android.util.Log;
-import android.widget.Toast;
 
 import java.util.ArrayList;
-import java.util.List;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentActivity;
-import io.treehouses.remote.Fragments.TerminalFragment;
 import io.treehouses.remote.Network.BluetoothChatService;
 
 /**

--- a/app/src/main/java/io/treehouses/remote/Fragments/AboutFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/AboutFragment.java
@@ -2,7 +2,6 @@ package io.treehouses.remote.Fragments;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/AddCommandDialogFragment.java
@@ -6,7 +6,6 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ChPasswordDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ChPasswordDialogFragment.java
@@ -3,7 +3,6 @@ package io.treehouses.remote.Fragments.DialogFragments;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ContainerDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/ContainerDialogFragment.java
@@ -12,9 +12,10 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 
+import androidx.fragment.app.DialogFragment;
+
 import java.util.ArrayList;
 
-import androidx.fragment.app.DialogFragment;
 import io.treehouses.remote.R;
 
 public class ContainerDialogFragment extends DialogFragment {

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
@@ -25,6 +25,7 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.Switch;
 import android.widget.Toast;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RenameDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RenameDialogFragment.java
@@ -3,7 +3,6 @@ package io.treehouses.remote.Fragments.DialogFragments;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/WifiDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/WifiDialogFragment.java
@@ -17,16 +17,17 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
-import androidx.fragment.app.DialogFragment;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import io.treehouses.remote.utils.ButtonConfiguration;
-import io.treehouses.remote.R;
-import io.treehouses.remote.utils.Utils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.treehouses.remote.R;
+import io.treehouses.remote.utils.ButtonConfiguration;
 
 public class WifiDialogFragment extends DialogFragment {
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/DockerContainerFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DockerContainerFragment.java
@@ -1,7 +1,6 @@
 package io.treehouses.remote.Fragments;
 
 import android.os.Bundle;
-import androidx.fragment.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,6 +8,8 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
+
+import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -7,14 +7,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.AnimationDrawable;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.os.Handler;
 import android.os.Message;
-
-import android.text.SpannableString;
-import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
-
+import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,18 +23,16 @@ import androidx.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
+import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.DialogFragments.RPIDialogFragment;
 import io.treehouses.remote.InitialActivity;
-import io.treehouses.remote.Constants;
 import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.Network.ParseDbService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.bases.BaseHomeFragment;
-import io.treehouses.remote.callback.SetDisconnect;
-
-import io.treehouses.remote.utils.VersionUtils;
 import io.treehouses.remote.callback.NotificationCallback;
+import io.treehouses.remote.callback.SetDisconnect;
 
 import static io.treehouses.remote.Constants.REQUEST_ENABLE_BT;
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/NetworkFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/NetworkFragment.java
@@ -16,17 +16,16 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
-import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.DialogFragments.WifiDialogFragment;
+import io.treehouses.remote.Network.BluetoothChatService;
+import io.treehouses.remote.R;
 import io.treehouses.remote.adapter.NetworkListAdapter;
 import io.treehouses.remote.adapter.ViewHolderReboot;
 import io.treehouses.remote.bases.BaseFragment;
-import io.treehouses.remote.Constants;
-import io.treehouses.remote.Network.BluetoothChatService;
-import io.treehouses.remote.R;
 import io.treehouses.remote.pojo.NetworkListItem;
+import io.treehouses.remote.utils.ButtonConfiguration;
 
 public class NetworkFragment extends BaseFragment {
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.java
@@ -1,29 +1,14 @@
 package io.treehouses.remote.Fragments;
 
-import android.app.Fragment;
-import android.content.Context;
 import android.os.Bundle;
-import androidx.viewpager.widget.ViewPager;
-import androidx.*;
-import androidx.viewpager.widget.PagerAdapter;
-import androidx.fragment.app.FragmentTransaction;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.tabs.TabLayout;
-
-import java.util.ArrayList;
 
 import io.treehouses.remote.R;
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/ServicesTabFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/ServicesTabFragment.java
@@ -9,9 +9,9 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
-import java.util.ArrayList;
-
 import androidx.fragment.app.Fragment;
+
+import java.util.ArrayList;
 
 import io.treehouses.remote.R;
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
@@ -1,20 +1,13 @@
 package io.treehouses.remote.Fragments;
 
 import android.os.Bundle;
-import android.preference.ListPreference;
 import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import io.treehouses.remote.R;
-import io.treehouses.remote.bases.BaseFragment;
 import io.treehouses.remote.utils.SaveUtils;
 
 public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceClickListener {

--- a/app/src/main/java/io/treehouses/remote/Fragments/SimpleFragmentPagerAdapter.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SimpleFragmentPagerAdapter.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
-import io.treehouses.remote.R;
 
 public class SimpleFragmentPagerAdapter extends FragmentPagerAdapter {
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/StatusFragment.java
@@ -1,13 +1,5 @@
 package io.treehouses.remote.Fragments;
 
-import androidx.cardview.widget.CardView;
-import io.treehouses.remote.Constants;
-import io.treehouses.remote.Network.BluetoothChatService;
-import io.treehouses.remote.R;
-import io.treehouses.remote.bases.BaseFragment;
-
-import io.treehouses.remote.callback.NotificationCallback;
-
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -25,8 +17,16 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.cardview.widget.CardView;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import io.treehouses.remote.Constants;
+import io.treehouses.remote.Network.BluetoothChatService;
+import io.treehouses.remote.R;
+import io.treehouses.remote.bases.BaseFragment;
+import io.treehouses.remote.callback.NotificationCallback;
 
 public class StatusFragment extends BaseFragment {
     View view;

--- a/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
@@ -20,9 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import io.treehouses.remote.Constants;
-import io.treehouses.remote.Fragments.DialogFragments.ChPasswordDialogFragment;
-import io.treehouses.remote.Fragments.DialogFragments.ContainerDialogFragment;
-import io.treehouses.remote.Fragments.DialogFragments.RenameDialogFragment;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.adapter.NetworkListAdapter;

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -6,8 +6,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;

--- a/app/src/main/java/io/treehouses/remote/Fragments/TextBoxValidation.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TextBoxValidation.java
@@ -1,7 +1,6 @@
 package io.treehouses.remote.Fragments;
 
 import android.app.AlertDialog;
-import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.text.Editable;

--- a/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
@@ -14,10 +14,6 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.Switch;
 import android.widget.TextView;
-import android.widget.Toast;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 
@@ -26,7 +22,6 @@ import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.bases.BaseTerminalFragment;
-import io.treehouses.remote.bases.BaseFragment;
 
 @SuppressWarnings("SpellCheckingInspection")
 public class TunnelFragment extends BaseTerminalFragment {

--- a/app/src/main/java/io/treehouses/remote/InitialActivity.java
+++ b/app/src/main/java/io/treehouses/remote/InitialActivity.java
@@ -5,24 +5,26 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.location.LocationManager;
 import android.os.Bundle;
-
 import android.os.Handler;
 import android.os.Message;
 import android.util.Log;
-
-import com.google.android.material.navigation.NavigationView;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
+
+import com.google.android.material.navigation.NavigationView;
+
 import io.treehouses.remote.Fragments.AboutFragment;
 import io.treehouses.remote.Fragments.HomeFragment;
 import io.treehouses.remote.Fragments.NetworkFragment;
@@ -35,16 +37,9 @@ import io.treehouses.remote.Fragments.TunnelFragment;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.bases.PermissionActivity;
 import io.treehouses.remote.callback.HomeInteractListener;
-
 import io.treehouses.remote.callback.NotificationCallback;
-
 import io.treehouses.remote.utils.GPSService;
-
 import io.treehouses.remote.utils.LogUtils;
-
-import android.view.Menu;
-import android.view.MenuItem;
-import android.widget.Toast;
 
 
 public class InitialActivity extends PermissionActivity

--- a/app/src/main/java/io/treehouses/remote/MainApplication.java
+++ b/app/src/main/java/io/treehouses/remote/MainApplication.java
@@ -3,7 +3,6 @@ package io.treehouses.remote;
 import android.app.Application;
 
 import com.parse.Parse;
-import com.parse.ParseObject;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/io/treehouses/remote/Network/BluetoothChatService.java
+++ b/app/src/main/java/io/treehouses/remote/Network/BluetoothChatService.java
@@ -37,9 +37,9 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.UUID;
 
-import io.treehouses.remote.Fragments.HomeFragment;
-import io.treehouses.remote.Fragments.DialogFragments.RPIDialogFragment;
 import io.treehouses.remote.Constants;
+import io.treehouses.remote.Fragments.DialogFragments.RPIDialogFragment;
+import io.treehouses.remote.Fragments.HomeFragment;
 
 /**
  * This class does all the work for setting up and managing Bluetooth

--- a/app/src/main/java/io/treehouses/remote/SplashScreenActivity.java
+++ b/app/src/main/java/io/treehouses/remote/SplashScreenActivity.java
@@ -1,8 +1,5 @@
 package io.treehouses.remote;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceManager;
-
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -11,6 +8,9 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceManager;
 
 public class SplashScreenActivity extends AppCompatActivity {
 

--- a/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.java
@@ -1,7 +1,6 @@
 package io.treehouses.remote.adapter;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/io/treehouses/remote/adapter/RPIListAdapter.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/RPIListAdapter.java
@@ -12,7 +12,6 @@ import androidx.core.content.ContextCompat;
 
 import java.util.List;
 
-import io.treehouses.remote.Fragments.DialogFragments.RPIDialogFragment;
 import io.treehouses.remote.R;
 import io.treehouses.remote.pojo.DeviceInfo;
 

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
@@ -1,17 +1,19 @@
 package io.treehouses.remote.adapter;
 
-import android.graphics.Color;
 import android.content.Context;
+import android.graphics.Color;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
+
 import com.google.android.material.textfield.TextInputEditText;
-import io.treehouses.remote.utils.ButtonConfiguration;
+
 import io.treehouses.remote.R;
-import io.treehouses.remote.utils.TextWatcherUtils;
 import io.treehouses.remote.callback.HomeInteractListener;
+import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.utils.TextWatcherUtils;
 
 public class ViewHolderBridge extends ButtonConfiguration {
     private TextInputEditText etPassword, etHotspotPassword;

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderEthernet.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderEthernet.java
@@ -1,14 +1,14 @@
 package io.treehouses.remote.adapter;
 
-import android.graphics.Color;
 import android.content.Context;
+import android.graphics.Color;
 import android.view.View;
 import android.widget.Toast;
 
-import io.treehouses.remote.utils.ButtonConfiguration;
 import io.treehouses.remote.R;
-import io.treehouses.remote.utils.TextWatcherUtils;
 import io.treehouses.remote.callback.HomeInteractListener;
+import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.utils.TextWatcherUtils;
 
 public class ViewHolderEthernet extends ButtonConfiguration {
 

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderHotspot.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderHotspot.java
@@ -1,16 +1,17 @@
 package io.treehouses.remote.adapter;
 
-import android.graphics.Color;
 import android.content.Context;
+import android.graphics.Color;
 import android.text.InputType;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.Toast;
-import io.treehouses.remote.utils.ButtonConfiguration;
+
 import io.treehouses.remote.R;
-import io.treehouses.remote.utils.TextWatcherUtils;
 import io.treehouses.remote.callback.HomeInteractListener;
+import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.utils.TextWatcherUtils;
 
 class ViewHolderHotspot extends ButtonConfiguration{
     private EditText etPassword;

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderReboot.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderReboot.java
@@ -6,9 +6,9 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
+import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.HomeFragment;
 import io.treehouses.remote.Fragments.NetworkFragment;
-import io.treehouses.remote.Constants;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.callback.HomeInteractListener;

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderReset.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderReset.java
@@ -2,6 +2,7 @@ package io.treehouses.remote.adapter;
 
 import android.view.View;
 import android.widget.Button;
+
 import io.treehouses.remote.Fragments.NetworkFragment;
 import io.treehouses.remote.R;
 

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderTether.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderTether.java
@@ -3,17 +3,13 @@ package io.treehouses.remote.adapter;
 import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.wifi.WifiManager;
-import android.os.Build;
-import android.os.Handler;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
-import android.widget.Switch;
 import android.widget.Toast;
+
 import com.google.android.material.textfield.TextInputEditText;
 
 import java.lang.reflect.InvocationTargetException;

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderVnc.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderVnc.java
@@ -9,9 +9,12 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.Switch;
 import android.widget.Toast;
+
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
+
 import java.util.List;
+
 import io.treehouses.remote.R;
 import io.treehouses.remote.callback.HomeInteractListener;
 

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
@@ -1,15 +1,17 @@
 package io.treehouses.remote.adapter;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.text.InputType;
 import android.view.View;
-import android.content.Context;
 import android.widget.Toast;
+
 import com.google.android.material.textfield.TextInputEditText;
-import io.treehouses.remote.utils.ButtonConfiguration;
+
 import io.treehouses.remote.R;
-import io.treehouses.remote.utils.TextWatcherUtils;
 import io.treehouses.remote.callback.HomeInteractListener;
+import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.utils.TextWatcherUtils;
 
 class ViewHolderWifi extends ButtonConfiguration {
 

--- a/app/src/main/java/io/treehouses/remote/bases/BaseDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseDialogFragment.java
@@ -3,6 +3,7 @@ package io.treehouses.remote.bases;
 import android.content.Context;
 
 import androidx.fragment.app.DialogFragment;
+
 import io.treehouses.remote.callback.HomeInteractListener;
 
 public class BaseDialogFragment extends DialogFragment {

--- a/app/src/main/java/io/treehouses/remote/bases/BaseFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseFragment.java
@@ -7,6 +7,7 @@ import android.os.Handler;
 import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
+
 import io.treehouses.remote.Constants;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.callback.HomeInteractListener;

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -10,7 +10,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
@@ -23,11 +22,9 @@ import androidx.preference.PreferenceManager;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import io.treehouses.remote.Constants;
-import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.utils.Utils;

--- a/app/src/main/java/io/treehouses/remote/bases/PermissionActivity.java
+++ b/app/src/main/java/io/treehouses/remote/bases/PermissionActivity.java
@@ -2,13 +2,11 @@ package io.treehouses.remote.bases;
 
 import android.Manifest;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;

--- a/app/src/main/java/io/treehouses/remote/callback/HomeInteractListener.java
+++ b/app/src/main/java/io/treehouses/remote/callback/HomeInteractListener.java
@@ -1,8 +1,7 @@
 package io.treehouses.remote.callback;
 
-import android.os.Handler;
-
 import androidx.fragment.app.Fragment;
+
 import io.treehouses.remote.Network.BluetoothChatService;
 
 public interface HomeInteractListener {

--- a/app/src/main/java/io/treehouses/remote/utils/ButtonConfiguration.java
+++ b/app/src/main/java/io/treehouses/remote/utils/ButtonConfiguration.java
@@ -1,12 +1,8 @@
 package io.treehouses.remote.utils;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.os.Build;
-import android.text.Editable;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.Toast;
 
 import com.google.android.material.textfield.TextInputEditText;

--- a/app/src/main/java/io/treehouses/remote/utils/GPSService.java
+++ b/app/src/main/java/io/treehouses/remote/utils/GPSService.java
@@ -22,8 +22,6 @@ import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 
-import io.treehouses.remote.MainApplication;
-
 public class GPSService extends Service implements LocationListener {
 
     private static final long MIN_DISTANCE_CHANGE_FOR_UPDATES = 10; // 10 meters

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -5,8 +5,6 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/app/src/main/java/io/treehouses/remote/utils/Utils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/Utils.java
@@ -3,14 +3,12 @@ package io.treehouses.remote.utils;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.net.wifi.WifiInfo;
-import android.net.wifi.WifiManager;
+import android.provider.Settings.Secure;
 import android.widget.Toast;
 
 import java.net.NetworkInterface;
 import java.util.Collections;
 import java.util.List;
-import android.provider.Settings.Secure;
 
 public class Utils {
     public static void copyToClipboard(Context context, String clickedData) {

--- a/app/src/main/res/layout/activity_docker_container_fragment.xml
+++ b/app/src/main/res/layout/activity_docker_container_fragment.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_initial.xml
+++ b/app/src/main/res/layout/activity_initial.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_rpi_dialog_fragment.xml
+++ b/app/src/main/res/layout/activity_rpi_dialog_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="400dp"
     android:layout_height="wrap_content"
     android:background="#FFF">

--- a/app/src/main/res/layout/activity_services_fragment.xml
+++ b/app/src/main/res/layout/activity_services_fragment.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#FFF">

--- a/app/src/main/res/layout/activity_services_tab_fragment.xml
+++ b/app/src/main/res/layout/activity_services_tab_fragment.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#FFF">

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal"

--- a/app/src/main/res/layout/activity_status_fragment.xml
+++ b/app/src/main/res/layout/activity_status_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"

--- a/app/src/main/res/layout/activity_system_fragment.xml
+++ b/app/src/main/res/layout/activity_system_fragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/md_white_1000"

--- a/app/src/main/res/layout/activity_tunnel_fragment.xml
+++ b/app/src/main/res/layout/activity_tunnel_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"

--- a/app/src/main/res/layout/cardlist.xml
+++ b/app/src/main/res/layout/cardlist.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/configure_tethering.xml
+++ b/app/src/main/res/layout/configure_tethering.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/dialog_bridge.xml
+++ b/app/src/main/res/layout/dialog_bridge.xml
@@ -1,5 +1,4 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/dialog_container.xml
+++ b/app/src/main/res/layout/dialog_container.xml
@@ -1,6 +1,5 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/dialog_design.xml
+++ b/app/src/main/res/layout/dialog_design.xml
@@ -29,7 +29,6 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/dialog_hotspot.xml
+++ b/app/src/main/res/layout/dialog_hotspot.xml
@@ -1,6 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:padding="@dimen/margin_medium"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_listview.xml
+++ b/app/src/main/res/layout/dialog_listview.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="400dp"
     android:layout_height="wrap_content"
     android:background="#FFF">

--- a/app/src/main/res/layout/dialog_rename.xml
+++ b/app/src/main/res/layout/dialog_rename.xml
@@ -1,6 +1,5 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/dialog_rename_status.xml
+++ b/app/src/main/res/layout/dialog_rename_status.xml
@@ -1,6 +1,5 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/dialog_reset.xml
+++ b/app/src/main/res/layout/dialog_reset.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/dialog_test_connection.xml
+++ b/app/src/main/res/layout/dialog_test_connection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="horizontal" android:layout_width="wrap_content"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="end">
 

--- a/app/src/main/res/layout/dialog_wifi.xml
+++ b/app/src/main/res/layout/dialog_wifi.xml
@@ -1,6 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"

--- a/app/src/main/res/layout/hope_layout.xml
+++ b/app/src/main/res/layout/hope_layout.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/hopeful"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/hotspot_dialog.xml
+++ b/app/src/main/res/layout/hotspot_dialog.xml
@@ -1,6 +1,5 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/app/src/main/res/layout/navigation_view_header.xml
+++ b/app/src/main/res/layout/navigation_view_header.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bottom_selected">

--- a/app/src/main/res/layout/terminal_options_list.xml
+++ b/app/src/main/res/layout/terminal_options_list.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/treehouses_layout.xml
+++ b/app/src/main/res/layout/treehouses_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/app/src/main/res/layout/tunnel_commands_list.xml
+++ b/app/src/main/res/layout/tunnel_commands_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical" android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView

--- a/app/src/main/res/menu/bluetooth_chat.xml
+++ b/app/src/main/res/menu/bluetooth_chat.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<menu xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"> <!--added so I could add other options into the menu-->
 
     <item

--- a/app/src/test/java/io/treehouses/remote/ExampleUnitTest.java
+++ b/app/src/test/java/io/treehouses/remote/ExampleUnitTest.java
@@ -2,7 +2,7 @@ package io.treehouses.remote;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
There is a megalith of imports that are importing code and commands into the compiled build that aren't being used. Over around 20-30+ imports that are unused besides just util.log.
I vote we remove them.

This ran fine in emulator Nexus 7. 
This was done by running Optimize Imports inside Android Studio. 