### PR TITLE
network: profiles with bridges (fixes #442)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.github.parse-community:ParseLiveQuery-Android:1.1.0'
 
+    implementation 'com.google.code.gson:gson:2.8.6'
+
+
     androidTestImplementation 'androidx.test:runner:1.1.1'
     implementation 'me.aflak.libraries:bluetooth:1.3.4'
 }

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.text.TextUtils;
 import android.util.Log;
 import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
@@ -44,7 +45,7 @@ import static io.treehouses.remote.Constants.REQUEST_ENABLE_BT;
 
 public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
     private static final String TAG = "HOME_FRAGMENT";
-    private static final String[] group_labels = {"WIFI", "Hotspot"};
+    private static final String[] group_labels = {"WiFi", "Hotspot", "Bridge"};
 
     private NotificationCallback notificationListener;
 
@@ -113,7 +114,8 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
             //WIFI
             listener.sendMessage(String.format("treehouses wifi \"%s\" \"%s\"", networkProfile.ssid, networkProfile.password));
             network_ssid = networkProfile.ssid;
-        } else if (networkProfile.isHotspot()){
+        }
+        else if (networkProfile.isHotspot()){
             //Hotspot
             if (networkProfile.password.isEmpty()) {
                 listener.sendMessage("treehouses ap \"" + networkProfile.option + "\" \"" + networkProfile.ssid + "\"");
@@ -122,9 +124,15 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
             }
             network_ssid = networkProfile.ssid;
         }
-        else {
-            Log.e("Home", "UNKNOWN TYPE");
+        else if (networkProfile.isBridge()) {
+            //Bridge
+            String temp = "treehouses bridge \"" + networkProfile.ssid + "\" \"" + networkProfile.hotspot_ssid + "\" ";
+            String overallMessage = TextUtils.isEmpty(networkProfile.password) ? temp + "\"\"" : temp + "\"" + networkProfile.password + "\"" + " ";
+
+            if (!TextUtils.isEmpty(networkProfile.hotspot_password)) overallMessage += "\"" + networkProfile.hotspot_password + "\"";
+            listener.sendMessage(overallMessage);
         }
+        else { Log.e("Home", "UNKNOWN TYPE"); }
     }
 
     @Override

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -189,14 +189,6 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         if (mChatService.getState() == Constants.STATE_CONNECTED) {
             showLogDialog(preferences);
             transitionOnConnected();
-
-            welcome_text.setVisibility(View.GONE);
-            testConnection.setVisibility(View.VISIBLE);
-            connectRpi.setText("Disconnect");
-            connectRpi.setBackgroundResource(R.drawable.disconnect_rpi);
-            background.animate().translationY(150);
-            connectRpi.animate().translationY(110);
-            getStarted.animate().translationY(70);
             connectionState = true;
             writeToRPI("treehouses upgrade --check\n"); //Check upgrade status
             sendImageInfoCommand();
@@ -221,22 +213,6 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         logo.setVisibility(View.GONE);
     }
 
-    private void sendImageInfoCommand() {
-//        new Thread(() -> {
-//            try {
-               // Thread.sleep(200);
-                listener.sendMessage("treehouses bluetooth mac\n");
-               // Thread.sleep(200);
-                listener.sendMessage("treehouses image\n");
-               // Thread.sleep(200);
-                listener.sendMessage("treehouses version\n");
-//            } catch (InterruptedException e) {
-//                e.printStackTrace();
-//            }
-//        }).start();
-
-    }
-
     private void transitionDisconnected() {
         connectRpi.setText("Connect to RPI");
         testConnection.setVisibility(View.GONE);
@@ -247,6 +223,13 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         connectRpi.setBackgroundResource(R.drawable.connect_to_rpi);
         logo.setVisibility(View.VISIBLE);
         layout.setVisibility(View.GONE);
+    }
+
+    private void sendImageInfoCommand() {
+        listener.sendMessage("treehouses bluetooth mac\n");
+        listener.sendMessage("treehouses image\n");
+        listener.sendMessage("treehouses version\n");
+
     }
 
     private void showRPIDialog() {
@@ -295,10 +278,14 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         } else if (matchResult(output, "network", "successfully")) {
             Toast.makeText(getContext(), "Switched to " + network_ssid, Toast.LENGTH_LONG).show();
             progressBar.setVisibility(View.GONE);
+        } else if (output.toLowerCase().contains("bridge has been built")) {
+            progressBar.setVisibility(View.GONE);
+            Toast.makeText(getContext(), "Bridge Has Been Built", Toast.LENGTH_LONG).show();
         } else if (output.toLowerCase().contains("error")) {
             progressBar.setVisibility(View.GONE);
             Toast.makeText(getContext(), "Network Not Found", Toast.LENGTH_LONG).show();
         } else if (!result) {
+            //Test Connection
             result = true;
             dismissTestConnection();
         }

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -24,16 +23,13 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.DialogFragments.RPIDialogFragment;
 import io.treehouses.remote.InitialActivity;
 import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
-import io.treehouses.remote.Network.ParseDbService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.adapter.ProfilesListAdapter;
 import io.treehouses.remote.bases.BaseHomeFragment;
@@ -113,18 +109,21 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         progressBar.setVisibility(View.VISIBLE);
         Toast.makeText(getContext(), "Connecting...", Toast.LENGTH_LONG).show();
 
-        if (networkProfile.option.equals(SaveUtils.NONE)) {
+        if (networkProfile.isWifi()) {
             //WIFI
             listener.sendMessage(String.format("treehouses wifi \"%s\" \"%s\"", networkProfile.ssid, networkProfile.password));
             network_ssid = networkProfile.ssid;
-        } else {
+        } else if (networkProfile.isHotspot()){
             //Hotspot
-            if (networkProfile.password.equals(SaveUtils.NONE)) {
+            if (networkProfile.password.isEmpty()) {
                 listener.sendMessage("treehouses ap \"" + networkProfile.option + "\" \"" + networkProfile.ssid + "\"");
             } else {
                 listener.sendMessage("treehouses ap \"" + networkProfile.option + "\" \"" + networkProfile.ssid + "\" \"" + networkProfile.password + "\"");
             }
             network_ssid = networkProfile.ssid;
+        }
+        else {
+            Log.e("Home", "UNKNOWN TYPE");
         }
     }
 

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -267,11 +267,8 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
     private void readMessage(String output) {
         if (output.contains(" ") && output.split(" ").length == 2) {
             String[] result = output.split(" ");
-            for (String r : result)
-                checkImageInfo(r,  mChatService.getConnectedDeviceName());
-        } else {
-            checkImageInfo(output,  mChatService.getConnectedDeviceName());
-        }
+            for (String r : result) checkImageInfo(r,  mChatService.getConnectedDeviceName());
+        } else { checkImageInfo(output,  mChatService.getConnectedDeviceName()); }
 
         if (matchResult(output, "true", "false")) {
             notificationListener.setNotification(output.contains("true"));

--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
@@ -24,9 +24,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
         setPreferencesFromResource(R.xml.app_preferences, rootKey);
         Preference clearCommandsList = findPreference("clear_commands");
         Preference resetCommandsList = findPreference("reset_commands");
+        Preference clearNetworkProfiles = findPreference("network_profiles");
 
         setClickListener(clearCommandsList);
         setClickListener(resetCommandsList);
+        setClickListener(clearNetworkProfiles);
     }
 
     private void setClickListener(Preference preference) {
@@ -49,8 +51,10 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
                 SaveUtils.initCommandsList(getContext());
                 Toast.makeText(getContext(), "Commands has been reset to default", Toast.LENGTH_LONG).show();
                 break;
-            case "led_pattern":
-
+            case "network_profiles":
+                SaveUtils.clearProfiles(getContext());
+                Toast.makeText(getContext(), "Network Profiles have been reset", Toast.LENGTH_LONG).show();
+                break;
         }
         return false;
     }

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
@@ -12,12 +13,15 @@ import com.google.android.material.textfield.TextInputEditText;
 
 import io.treehouses.remote.R;
 import io.treehouses.remote.callback.HomeInteractListener;
+import io.treehouses.remote.pojo.NetworkProfile;
 import io.treehouses.remote.utils.ButtonConfiguration;
+import io.treehouses.remote.utils.SaveUtils;
 import io.treehouses.remote.utils.TextWatcherUtils;
 
 public class ViewHolderBridge extends ButtonConfiguration {
     private TextInputEditText etPassword, etHotspotPassword;
     private Button btnStartConfiguration;
+    private Button addBridgeProfile;
 
     public ViewHolderBridge(){}
 
@@ -29,6 +33,7 @@ public class ViewHolderBridge extends ButtonConfiguration {
         etHotspotPassword = v.findViewById(R.id.et_hotspot_password);
         setBtnStartConfiguration(btnStartConfiguration = v.findViewById(R.id.btn_start_config));
         btnWifiSearch = v.findViewById(R.id.btnWifiSearch);
+        addBridgeProfile = v.findViewById(R.id.add_bridge_profile);
 
         try {
             essid.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
@@ -60,5 +65,17 @@ public class ViewHolderBridge extends ButtonConfiguration {
 
             Toast.makeText(context, "Connecting...", Toast.LENGTH_LONG).show();
         });
+
+        addBridgeProfile.setOnClickListener(view -> {
+            Log.d("SSID", etSsid.getText().toString());
+            NetworkProfile networkProfile = new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString(),
+                    etHotspotEssid.getText().toString(), etHotspotPassword.getText().toString());
+
+            SaveUtils.addProfile(context, networkProfile);
+            Toast.makeText(context, "Bridge Profile Added", Toast.LENGTH_LONG).show();
+        });
+
+
     }
+
 }

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderBridge.java
@@ -67,8 +67,8 @@ public class ViewHolderBridge extends ButtonConfiguration {
         });
 
         addBridgeProfile.setOnClickListener(view -> {
-            Log.d("SSID", etSsid.getText().toString());
-            NetworkProfile networkProfile = new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString(),
+            Log.d("SSID", essid.getText().toString());
+            NetworkProfile networkProfile = new NetworkProfile(essid.getText().toString(), etPassword.getText().toString(),
                     etHotspotEssid.getText().toString(), etHotspotPassword.getText().toString());
 
             SaveUtils.addProfile(context, networkProfile);

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderHotspot.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderHotspot.java
@@ -51,7 +51,7 @@ class ViewHolderHotspot extends ButtonConfiguration{
             @Override
             public void onClick(View v) {
                 SaveUtils.addProfile(context, new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString(), spn.getSelectedItem().toString()));
-                Toast.makeText(context, "Profile Saved", Toast.LENGTH_LONG).show();
+                Toast.makeText(context, "Hotspot Profile Saved", Toast.LENGTH_LONG).show();
             }
         });
     }

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
@@ -59,7 +59,7 @@ class ViewHolderWifi extends ButtonConfiguration {
             @Override
             public void onClick(View v) {
                 SaveUtils.addProfile(context, new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString()));
-                Toast.makeText(context, "Profile Saved", Toast.LENGTH_LONG).show();
+                Toast.makeText(context, "WiFi Profile Saved", Toast.LENGTH_LONG).show();
             }
         });
 

--- a/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
+++ b/app/src/main/java/io/treehouses/remote/adapter/ViewHolderWifi.java
@@ -58,7 +58,7 @@ class ViewHolderWifi extends ButtonConfiguration {
         saveProfile.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                SaveUtils.addProfile(context, new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString(),""));
+                SaveUtils.addProfile(context, new NetworkProfile(etSsid.getText().toString(), etPassword.getText().toString()));
                 Toast.makeText(context, "Profile Saved", Toast.LENGTH_LONG).show();
             }
         });

--- a/app/src/main/java/io/treehouses/remote/pojo/NetworkProfile.java
+++ b/app/src/main/java/io/treehouses/remote/pojo/NetworkProfile.java
@@ -6,17 +6,46 @@ public class NetworkProfile {
     public String ssid;
     public String password;
     public String option;
-    //Hotspot
-    public NetworkProfile(String ssid, String password, String option) {
-        this.ssid = ssid;
-        this.password = password;
-        this.option = option;
-    }
+
+    //For Bridge
+    public String hotspot_ssid;
+    public String hotspot_password;
+
+    private int profileType;
 
     //Wifi
     public NetworkProfile(String ssid, String password) {
         this.ssid = ssid;
         this.password = password;
-        this.option = SaveUtils.NONE;
+        this.profileType = 0;
+    }
+
+    //Hotspot
+    public NetworkProfile(String ssid, String password, String option) {
+        this.ssid = ssid;
+        this.password = password;
+        this.option = option;
+        this.profileType = 1;
+    }
+
+    //Bridge
+    public NetworkProfile(String ssid, String password, String hotspotSSID, String hotspotPassword) {
+        this.ssid = ssid;
+        this.password = password;
+        this.hotspot_ssid = hotspotSSID;
+        this.hotspot_password = hotspotPassword;
+        this.profileType = 2;
+    }
+
+    public boolean isWifi() {
+        return this.profileType == 0;
+    }
+
+    public boolean isHotspot() {
+        return this.profileType == 1;
+    }
+
+    public boolean isBridge() {
+        return this.profileType == 2;
     }
 }

--- a/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/SaveUtils.java
@@ -136,7 +136,6 @@ public class SaveUtils {
 
     public static void addProfile(Context context, NetworkProfile profile) {
         Gson gson = new Gson();
-        Log.d("PROFILE", Integer.toString(profile.profileType));
         addToArrayList(context, NETWORK_PROFILES_KEY, gson.toJson(profile));
     }
 
@@ -145,21 +144,26 @@ public class SaveUtils {
         ArrayList<String> json_profiles = getStringArray(context, NETWORK_PROFILES_KEY);
         ArrayList<NetworkProfile> wifi = new ArrayList<>();
         ArrayList<NetworkProfile> hotspot = new ArrayList<>();
+        ArrayList<NetworkProfile> bridge = new ArrayList<>();
         for (int i = 0; i < json_profiles.size(); i++) {
             NetworkProfile profile = gson.fromJson(json_profiles.get(i), NetworkProfile.class);
             if (profile.isWifi()) {
                 wifi.add(profile);
             }
-            else if (profile.isHotspot()){
+            else if (profile.isHotspot()) {
                 hotspot.add(profile);
+            }
+            else if (profile.isBridge()) {
+                bridge.add(profile);
             }
             else {
                 Log.e("SAVE UTILS", "Not a supported type");
             }
         }
         HashMap<String, List<NetworkProfile>> profiles = new HashMap<>();
-        profiles.put("WIFI", wifi);
+        profiles.put("WiFi", wifi);
         profiles.put("Hotspot", hotspot);
+        profiles.put("Bridge", bridge);
         return profiles;
     }
 

--- a/app/src/main/res/layout/dialog_bridge.xml
+++ b/app/src/main/res/layout/dialog_bridge.xml
@@ -74,7 +74,12 @@
     </com.google.android.material.textfield.TextInputLayout>
 
 
-
     <include layout="@layout/layout_btn_configuration" />
+
+    <Button
+        android:id="@+id/add_bridge_profile"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Add Bridge Profile" />
 
 </LinearLayout>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -9,16 +9,6 @@
             android:key="autocomplete"
             android:defaultValue="true" />
 
-        <Preference
-            android:title="Clear Commands List"
-            android:key="clear_commands"
-            android:summary="Clear the customizable commands list in terminal">
-        </Preference>
-        <Preference
-            android:title="Default Commands List"
-            android:key="reset_commands"
-            android:summary="Reset list to the default commands in terminal">
-        </Preference>
         <ListPreference
             android:defaultValue="LED Dance"
             android:entries="@array/led_options"
@@ -26,6 +16,27 @@
             android:key="led_pattern"
             android:title="LED Pattern"
             android:summary="Set the Test Connection LED Pattern"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="User Customization">
+        <Preference
+            android:title="Clear Commands List"
+            android:key="clear_commands"
+            android:summary="Clear the customizable commands list in terminal">
+        </Preference>
+
+        <Preference
+            android:title="Default Commands List"
+            android:key="reset_commands"
+            android:summary="Reset list to the default commands in terminal">
+        </Preference>
+
+        <Preference
+            android:title="Clear Network Profiles"
+            android:key="network_profiles"
+            android:summary="Clear all Network Profiles (WIFI, Hotspot, Bridge)">
+        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="About">


### PR DESCRIPTION
# Fixes #442 
## Features Added
* Converted objects to JSON before storing in SharedPreferences to allow for greater adaptability
* Added `Clear Network Profiles` in Settings
* Implemented `Bridge` Function: Now available

## Next Steps
* When no profiles are available, ask to go to Network Fragment to configure
* Show ProgressBar in AlertDialog with title "Connecting" instead of separate ProgressBar and Toast Message
* Individual Delete and Edit Profiles from HomeFragment

## Screenshots
<img width="434" alt="Screen Shot 2020-01-08 at 11 21 45 PM" src="https://user-images.githubusercontent.com/37857112/72038152-7d684c00-326e-11ea-942b-c9314ae203e5.png">
<img width="433" alt="Screen Shot 2020-01-08 at 11 22 05 PM" src="https://user-images.githubusercontent.com/37857112/72038161-848f5a00-326e-11ea-98ce-0b3c8ffe866e.png">
