### PR TITLE
home: handle empty profiles list (fixes #617)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -14,6 +14,7 @@ import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ExpandableListView;
 import android.widget.FrameLayout;
@@ -98,8 +99,10 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         network_profiles.setOnChildClickListener(new ExpandableListView.OnChildClickListener() {
             @Override
             public boolean onChildClick(ExpandableListView parent, View v, int groupPosition, int childPosition, long id) {
-                NetworkProfile networkProfile = SaveUtils.getProfiles(getContext()).get(Arrays.asList(group_labels).get(groupPosition)).get(childPosition);
-                switchProfile(networkProfile);
+                if (SaveUtils.getProfiles(getContext()).size() > 0 && SaveUtils.getProfiles(getContext()).get(Arrays.asList(group_labels).get(groupPosition)).size() > 0) {
+                    NetworkProfile networkProfile = SaveUtils.getProfiles(getContext()).get(Arrays.asList(group_labels).get(groupPosition)).get(childPosition);
+                    switchProfile(networkProfile);
+                }
                 return false;
             }
         });


### PR DESCRIPTION
# Fixes #617 

## Issues Fixed
- OnClick of the child was producing index out of bounds exception
- Added check to make sure size of lists are greater than 0 before indexing

