### PR TITLE
terminal: add spaces to autocomplete textview (fixes #639)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -159,8 +159,7 @@ public class BaseTerminalFragment extends BaseFragment{
             autoComplete.setAdapter(arrayAdapter);
             autoComplete.addTextChangedListener(new TextWatcher() {
                 @Override
-                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                }
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
 
                 @Override
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -168,16 +167,17 @@ public class BaseTerminalFragment extends BaseFragment{
                     else autoComplete.setAdapter(arrayAdapter);
                 }
                 @Override
-                public void afterTextChanged(Editable s) {
-                }
-            });
-
-            autoComplete.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                @Override
-                public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                    autoComplete.append(" ");
-                }
-            });
+                public void afterTextChanged(Editable s) { } });
+            addSpaces(autoComplete);
         }
+    }
+    private void addSpaces(AutoCompleteTextView autoComplete) {
+        autoComplete.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                autoComplete.append(" ");
+            }
+        });
+
     }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -10,6 +10,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
@@ -168,6 +169,13 @@ public class BaseTerminalFragment extends BaseFragment{
                 }
                 @Override
                 public void afterTextChanged(Editable s) {
+                }
+            });
+
+            autoComplete.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                @Override
+                public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                    autoComplete.append(" ");
                 }
             });
         }


### PR DESCRIPTION
Add spaces after clicking a command from the autocomplete textview in the terminal.