### PR TITLE
terminal: send text on newline (fixes #652)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -159,9 +159,6 @@ public class TerminalFragment extends BaseTerminalFragment {
         };
         mConversationView.setAdapter(mConversationArrayAdapter);
 
-        // Initialize the compose field with a listener for the return key
-        addTextChangeListener(mOutEditText);
-
         btnSendClickListener();
 
         // Initialize the BluetoothChatService to perform bluetooth connections

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -179,17 +179,13 @@ public class TerminalFragment extends BaseTerminalFragment {
                 consoleInput.setText("");
             }
         });
-        mPrevious.setOnClickListener(v -> { setLastCommand(); });
+        mPrevious.setOnClickListener(v -> {
+            try {
+                last = list.get(--i);
+                mOutEditText.setText(last);
+                mOutEditText.setSelection(mOutEditText.length());
+            } catch (Exception e) { e.printStackTrace(); } });
     }
-
-    private void setLastCommand() {
-        try {
-            last = list.get(--i);
-            mOutEditText.setText(last);
-            mOutEditText.setSelection(mOutEditText.length());
-        } catch (Exception e) { e.printStackTrace(); }
-    }
-
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -201,7 +197,14 @@ public class TerminalFragment extends BaseTerminalFragment {
                 onResultCaseDialogChpass(resultCode, data);
                 break;
             case Constants.REQUEST_DIALOG_FRAGMENT_ADD_COMMAND:
-                onResultAddCommand(resultCode);
+                if (resultCode == Activity.RESULT_OK) {
+                    expandableListDetail.clear();
+                    expandableListDetail.put(TITLE_EXPANDABLE, SaveUtils.getCommandsList(getContext()));
+                    expandableListTitle = new ArrayList<>(expandableListDetail.keySet());
+                    expandableListAdapter = new CommandListAdapter(getContext(), expandableListTitle, expandableListDetail);
+                    expandableListView.setAdapter(expandableListAdapter);
+                    expandableListView.expandGroup(0,true);
+                }
                 break;
         }
     }
@@ -219,16 +222,6 @@ public class TerminalFragment extends BaseTerminalFragment {
         }
     }
 
-    private void onResultAddCommand(int resultcode) {
-        if (resultcode == Activity.RESULT_OK) {
-            expandableListDetail.clear();
-            expandableListDetail.put(TITLE_EXPANDABLE, SaveUtils.getCommandsList(getContext()));
-            expandableListTitle = new ArrayList<>(expandableListDetail.keySet());
-            expandableListAdapter = new CommandListAdapter(getContext(), expandableListTitle, expandableListDetail);
-            expandableListView.setAdapter(expandableListAdapter);
-            expandableListView.expandGroup(0,true);
-        }
-    }
 
     public void showDialog(androidx.fragment.app.DialogFragment dialogFrag, int requestCode, String tag) {
         // Create an instance of the dialog fragment and show it

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -220,7 +220,7 @@ public class TerminalFragment extends BaseTerminalFragment {
     }
 
 
-    public void showDialog(androidx.fragment.app.DialogFragment dialogFrag, int requestCode, String tag) {
+    private void showDialog(androidx.fragment.app.DialogFragment dialogFrag, int requestCode, String tag) {
         // Create an instance of the dialog fragment and show it
         dialogFrag.setTargetFragment(this, requestCode);
         dialogFrag.show(getFragmentManager().beginTransaction(), tag);
@@ -230,6 +230,16 @@ public class TerminalFragment extends BaseTerminalFragment {
         MainApplication.getCommandList().add(writeMessage);
         list = MainApplication.getCommandList();
         i = list.size();
+    }
+    private void onResultCaseDialogChpass(int resultCode, Intent data) {
+        if (resultCode == Activity.RESULT_OK) {
+            //get password change request
+            String chPWD = data.getStringExtra("password") == null ? "" : data.getStringExtra("password");
+            //store password and command
+            String password = "treehouses password " + chPWD;
+            //send password to command line interface
+            listener.sendMessage(password);
+        }
     }
 
     /**

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -158,7 +160,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         mConversationView.setAdapter(mConversationArrayAdapter);
 
         // Initialize the compose field with a listener for the return key
-        mOutEditText.setOnEditorActionListener(mWriteListener);
+        addTextChangeListener();
 
         btnSendClickListener();
 
@@ -188,20 +190,24 @@ public class TerminalFragment extends BaseTerminalFragment {
         } catch (Exception e) { e.printStackTrace(); }
     }
 
-    /**
-     * The action listener for the EditText widget, to listen for the return key
-     */
-    private TextView.OnEditorActionListener mWriteListener = new TextView.OnEditorActionListener() {
-        public boolean onEditorAction(TextView view, int actionId, KeyEvent event) {
-            // If the action is a key-up event on the return key, send the message
-            if (actionId == EditorInfo.IME_NULL && event.getAction() == KeyEvent.ACTION_UP) {
-                String message = view.getText().toString();
-                listener.sendMessage(message);
-                mOutEditText.setText("");
+
+    private void addTextChangeListener() {
+        mOutEditText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) { }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (s.toString().endsWith("\n")) {
+                    listener.sendMessage(mOutEditText.getText().toString().substring(0,mOutEditText.getText().toString().length()-1));
+                    mOutEditText.setText("");
+                }
             }
-            return true;
-        }
-    };
+        });
+    }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -160,7 +160,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         mConversationView.setAdapter(mConversationArrayAdapter);
 
         // Initialize the compose field with a listener for the return key
-        addTextChangeListener();
+        addTextChangeListener(mOutEditText);
 
         btnSendClickListener();
 
@@ -191,24 +191,6 @@ public class TerminalFragment extends BaseTerminalFragment {
     }
 
 
-    private void addTextChangeListener() {
-        mOutEditText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) { }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                if (s.toString().endsWith("\n")) {
-                    listener.sendMessage(mOutEditText.getText().toString().substring(0,mOutEditText.getText().toString().length()-1));
-                    mOutEditText.setText("");
-                }
-            }
-        });
-    }
-
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         switch (requestCode) {
@@ -224,29 +206,19 @@ public class TerminalFragment extends BaseTerminalFragment {
         }
     }
 
-    private void onResultCaseDialogChpass(int resultCode, Intent data) {
-        if (resultCode == Activity.RESULT_OK) {
-            //get password change request
-            String chPWD = data.getStringExtra("password") == null ? "" : data.getStringExtra("password");
-            //store password and command
-            String password = "treehouses password " + chPWD;
-            //send password to command line interface
-            listener.sendMessage(password);
-        }
-    }
-
-    private void onResultCaseEnable(int resultCode) {
+    protected void onResultCaseEnable(int resultCode) {
         // When the request to enable Bluetooth returns
         if (resultCode == Activity.RESULT_OK) {
             // Bluetooth is now enabled, so set up a chat session
             setupChat();
         } else {
             // User did not enable Bluetooth or an error occurred
-            Log.d(TAG, "BT not enabled");
+            Log.d("TERMINAL", "BT not enabled");
             Toast.makeText(getActivity(), R.string.bt_not_enabled_leaving, Toast.LENGTH_SHORT).show();
             getActivity().finish();
         }
     }
+
     private void onResultAddCommand(int resultcode) {
         if (resultcode == Activity.RESULT_OK) {
             expandableListDetail.clear();

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -261,9 +261,7 @@ public class TerminalFragment extends BaseTerminalFragment {
                     handlerCaseName(msg, getActivity());
                     break;
                 case Constants.MESSAGE_TOAST:
-                    if (null != getActivity()) {
-                        Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
-                    }
+                    handlerCaseToast(msg);
                     break;
             }
         }

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -261,7 +261,9 @@ public class TerminalFragment extends BaseTerminalFragment {
                     handlerCaseName(msg, getActivity());
                     break;
                 case Constants.MESSAGE_TOAST:
-                    handlerCaseToast(msg);
+                    if (null != getActivity()) {
+                        Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
+                    }
                     break;
             }
         }

--- a/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
@@ -14,7 +14,6 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.Switch;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.util.ArrayList;
 
@@ -161,9 +160,7 @@ public class TunnelFragment extends BaseTerminalFragment {
                     handlerCaseName(msg, activity);
                     break;
                 case Constants.MESSAGE_TOAST:
-                    if (null != getActivity()) {
-                        Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
-                    }
+                    handlerCaseToast(msg);
                     break;
             }
         }

--- a/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TunnelFragment.java
@@ -14,6 +14,7 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.Switch;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 
@@ -160,7 +161,9 @@ public class TunnelFragment extends BaseTerminalFragment {
                     handlerCaseName(msg, activity);
                     break;
                 case Constants.MESSAGE_TOAST:
-                    handlerCaseToast(msg);
+                    if (null != getActivity()) {
+                        Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
+                    }
                     break;
             }
         }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -53,12 +53,6 @@ public class BaseTerminalFragment extends BaseFragment{
         }
     }
 
-    public void handlerCaseToast(Message msg) {
-        if (null != getActivity()) {
-            Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
-        }
-    }
-
     public View getViews(View view, Boolean isRead) {
         TextView consoleView = view.findViewById(R.id.listItem);
         if (isRead) {
@@ -75,7 +69,7 @@ public class BaseTerminalFragment extends BaseFragment{
         bgShape.setColor(color);
     }
 
-    protected void offline(TextView mPingStatus, Button pingStatusButton) {
+    private void offline(TextView mPingStatus, Button pingStatusButton) {
         mPingStatus.setText(R.string.bStatusOffline);
         bgResource(pingStatusButton, Color.RED);
     }
@@ -85,7 +79,7 @@ public class BaseTerminalFragment extends BaseFragment{
         bgResource(pingStatusButton, Color.YELLOW);
     }
 
-    public void connect(TextView mPingStatus, Button pingStatusButton) {
+    private void connect(TextView mPingStatus, Button pingStatusButton) {
         mPingStatus.setText(R.string.bStatusConnected);
         bgResource(pingStatusButton, Color.GREEN);
     }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -2,6 +2,7 @@ package io.treehouses.remote.bases;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
@@ -171,5 +172,33 @@ public class BaseTerminalFragment extends BaseFragment{
                 }
             });
         }
+    }
+
+    protected void onResultCaseDialogChpass(int resultCode, Intent data) {
+        if (resultCode == Activity.RESULT_OK) {
+            //get password change request
+            String chPWD = data.getStringExtra("password") == null ? "" : data.getStringExtra("password");
+            //store password and command
+            String password = "treehouses password " + chPWD;
+            //send password to command line interface
+            listener.sendMessage(password);
+        }
+    }
+    protected void addTextChangeListener(AutoCompleteTextView autoCompleteTextView) {
+        autoCompleteTextView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) { }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (s.toString().endsWith("\n")) {
+                    listener.sendMessage(autoCompleteTextView.getText().toString().substring(0,autoCompleteTextView.getText().toString().length()-1));
+                    autoCompleteTextView.setText("");
+                }
+            }
+        });
     }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -169,6 +169,10 @@ public class BaseTerminalFragment extends BaseFragment{
                 }
                 @Override
                 public void afterTextChanged(Editable s) {
+                    if (s.toString().endsWith("\n")) {
+                        listener.sendMessage(autoComplete.getText().toString().substring(0,autoComplete.getText().toString().length()-1));
+                        autoComplete.setText("");
+                    }
                 }
             });
         }
@@ -183,22 +187,5 @@ public class BaseTerminalFragment extends BaseFragment{
             //send password to command line interface
             listener.sendMessage(password);
         }
-    }
-    protected void addTextChangeListener(AutoCompleteTextView autoCompleteTextView) {
-        autoCompleteTextView.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) { }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                if (s.toString().endsWith("\n")) {
-                    listener.sendMessage(autoCompleteTextView.getText().toString().substring(0,autoCompleteTextView.getText().toString().length()-1));
-                    autoCompleteTextView.setText("");
-                }
-            }
-        });
     }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -32,6 +32,7 @@ import io.treehouses.remote.R;
 import io.treehouses.remote.utils.Utils;
 
 public class BaseTerminalFragment extends BaseFragment{
+    private final String[] array2 = {"treehouses", "docker"};
 
     public String handlerCaseWrite(String TAG, ArrayAdapter<String> mConversationArrayAdapter, Message msg) {
 
@@ -153,7 +154,6 @@ public class BaseTerminalFragment extends BaseFragment{
 
         if (preferences.getBoolean("autocomplete", true)) {
             final String[] commands = getResources().getStringArray(R.array.commands_list);
-            final String[] array2 = {"treehouses", "docker"};
             ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, commands);
             ArrayAdapter<String> arrayAdapter1 = new ArrayAdapter<String>(getContext(), android.R.layout.simple_dropdown_item_1line, array2);
             autoComplete.setThreshold(1);
@@ -173,22 +173,11 @@ public class BaseTerminalFragment extends BaseFragment{
                         listener.sendMessage(autoComplete.getText().toString().substring(0,autoComplete.getText().toString().length()-1));
                         autoComplete.setText("");
                     }
-                }
-            });
+                }});
             addSpaces(autoComplete);
         }
     }
 
-    protected void onResultCaseDialogChpass(int resultCode, Intent data) {
-        if (resultCode == Activity.RESULT_OK) {
-            //get password change request
-            String chPWD = data.getStringExtra("password") == null ? "" : data.getStringExtra("password");
-            //store password and command
-            String password = "treehouses password " + chPWD;
-            //send password to command line interface
-            listener.sendMessage(password);
-        }
-    }
     private void addSpaces(AutoCompleteTextView autoComplete) {
         autoComplete.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -80,7 +80,7 @@ public class BaseTerminalFragment extends BaseFragment{
         bgResource(pingStatusButton, Color.RED);
     }
 
-    public void idle(TextView mPingStatus, Button pingStatusButton) {
+    protected void idle(TextView mPingStatus, Button pingStatusButton) {
         mPingStatus.setText(R.string.bStatusIdle);
         bgResource(pingStatusButton, Color.YELLOW);
     }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -53,6 +53,12 @@ public class BaseTerminalFragment extends BaseFragment{
         }
     }
 
+    public void handlerCaseToast(Message msg) {
+        if (null != getActivity()) {
+            Toast.makeText(getActivity(), msg.getData().getString(Constants.TOAST), Toast.LENGTH_SHORT).show();
+        }
+    }
+
     public View getViews(View view, Boolean isRead) {
         TextView consoleView = view.findViewById(R.id.listItem);
         if (isRead) {
@@ -69,7 +75,7 @@ public class BaseTerminalFragment extends BaseFragment{
         bgShape.setColor(color);
     }
 
-    private void offline(TextView mPingStatus, Button pingStatusButton) {
+    protected void offline(TextView mPingStatus, Button pingStatusButton) {
         mPingStatus.setText(R.string.bStatusOffline);
         bgResource(pingStatusButton, Color.RED);
     }
@@ -79,7 +85,7 @@ public class BaseTerminalFragment extends BaseFragment{
         bgResource(pingStatusButton, Color.YELLOW);
     }
 
-    private void connect(TextView mPingStatus, Button pingStatusButton) {
+    public void connect(TextView mPingStatus, Button pingStatusButton) {
         mPingStatus.setText(R.string.bStatusConnected);
         bgResource(pingStatusButton, Color.GREEN);
     }


### PR DESCRIPTION
# Fixes #652 
When the user presses the enter key on either the soft keyboard or the physical keyboard, the text is sent.

Done by checking if the last character of the string is a '\n'.