### PR TITLE
home: remote version command check (fixes #656)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -280,19 +280,6 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         }
     }
 
-    private void showUpgradeCLI() {
-        AlertDialog alertDialog = new AlertDialog.Builder(getContext())
-                .setTitle("Update Treehouses CLI")
-                .setMessage("Treehouses CLI needs an upgrade to correctly function with Treehouses Remote. Please upgrade to the latest version!")
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                }).create();
-        alertDialog.show();
-    }
-
     private void readMessage(String output) {
         if (checkVersionSent) {
             checkVersion(output);

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -283,6 +283,9 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
     private void readMessage(String output) {
         if (checkVersionSent) {
             checkVersion(output);
+        }
+        else if (output.contains("updated")) {
+            dismissPDialog();
         } else if (output.contains(" ") && output.split(" ").length == 5) {
             checkImageInfo(output.split(" "), mChatService.getConnectedDeviceName());
         } else if (matchResult(output, "true", "false") && output.length() < 14) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -283,9 +283,6 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
     private void readMessage(String output) {
         if (checkVersionSent) {
             checkVersion(output);
-        }
-        else if (output.contains("updated")) {
-            dismissPDialog();
         } else if (output.contains(" ") && output.split(" ").length == 5) {
             checkImageInfo(output.split(" "), mChatService.getConnectedDeviceName());
         } else if (matchResult(output, "true", "false") && output.length() < 14) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -251,9 +251,13 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
 
     private void dismissPDialog() { if (progressDialog != null) progressDialog.dismiss(); }
 
-    private void checkVersion(boolean b) {
+    private void checkVersion(String output) {
         checkVersionSent = false;
-        if (BuildConfig.VERSION_CODE == 2 || b) {
+        if (output.contains("Usage") || output.contains("command")) {
+            //CLI Needs Upgrade
+            showUpgradeCLI();
+        }
+        else if(BuildConfig.VERSION_CODE == 2 || output.contains("true")) {
             writeToRPI("treehouses remote status\n");
             writeToRPI("treehouses upgrade --check\n");
         }
@@ -276,9 +280,22 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
         }
     }
 
+    private void showUpgradeCLI() {
+        AlertDialog alertDialog = new AlertDialog.Builder(getContext())
+                .setTitle("Update Treehouses CLI")
+                .setMessage("Treehouses CLI needs an upgrade to correctly function with Treehouses Remote. Please upgrade to the latest version!")
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                }).create();
+        alertDialog.show();
+    }
+
     private void readMessage(String output) {
         if (checkVersionSent) {
-            checkVersion(output.contains("true"));
+            checkVersion(output);
         } else if (output.contains(" ") && output.split(" ").length == 5) {
             checkImageInfo(output.split(" "), mChatService.getConnectedDeviceName());
         } else if (matchResult(output, "true", "false") && output.length() < 14) {

--- a/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.java
@@ -1,6 +1,7 @@
 package io.treehouses.remote.bases;
 
 import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.drawable.AnimationDrawable;
 import android.text.SpannableString;
@@ -172,4 +173,17 @@ public class BaseHomeFragment extends BaseFragment {
 
     protected boolean matchResult(String output, String option1, String option2) { return output.contains(option1) || output.contains(option2); }
 
+
+    protected void showUpgradeCLI() {
+        AlertDialog alertDialog = new AlertDialog.Builder(getContext())
+                .setTitle("Update Treehouses CLI")
+                .setMessage("Treehouses CLI needs an upgrade to correctly function with Treehouses Remote. Please upgrade to the latest version!")
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                }).create();
+        alertDialog.show();
+    }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.java
@@ -1,6 +1,7 @@
 package io.treehouses.remote.bases;
 
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.drawable.AnimationDrawable;
@@ -9,9 +10,11 @@ import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.content.Intent;
 import android.net.Uri;
+import android.widget.Toast;
 
 import java.util.Calendar;
 import java.util.HashMap;
@@ -178,12 +181,21 @@ public class BaseHomeFragment extends BaseFragment {
         AlertDialog alertDialog = new AlertDialog.Builder(getContext())
                 .setTitle("Update Treehouses CLI")
                 .setMessage("Treehouses CLI needs an upgrade to correctly function with Treehouses Remote. Please upgrade to the latest version!")
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                .setPositiveButton("Upgrade", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        listener.sendMessage("treehouses upgrade \n");
+                        Toast.makeText(getContext(), "Upgraded", Toast.LENGTH_LONG).show();
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton("Upgrade Later", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();
                     }
-                }).create();
+                })
+                .create();
         alertDialog.show();
     }
 }


### PR DESCRIPTION
# Fixes #656 

## Features
- Show alert if the `treehouses remote version` returns an error (CLI is outdated)

## Screenshots
<img width="441" alt="Screen Shot 2020-03-04 at 8 41 19 PM" src="https://user-images.githubusercontent.com/37857112/75939569-8a618000-5e58-11ea-9a68-a9ea80c7d1d8.png">
