### PR TITLE
network: dismiss wifi dialog properly (fixes #660)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/BottomSheetDialogs/WifiBottomSheet.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/BottomSheetDialogs/WifiBottomSheet.java
@@ -93,10 +93,6 @@ public class WifiBottomSheet extends BaseBottomSheetDialog {
             ssidText.setText(data.getStringExtra(WifiDialogFragment.WIFI_SSID_KEY));
         }
     }
-
-    @Override
-    public void onDismiss(final DialogInterface dialogInterface) {
-
-    }
+    
 
 }


### PR DESCRIPTION
# Fixes #660 
- Remove the overriding onDismiss() in WifiBottomSheetDialog