### PR TITLE
system: numberformat (fixes #662)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
@@ -128,10 +128,13 @@ public class SystemFragment extends BaseFragment {
 
         for (String element : array) {
             //TODO: Need to convert IPv6 addresses to long; currently it is being skipped
+            long ip = -1;
             if (checkElement(element)) {
-                long ip = ipToLong(element);
-                if (ip == -1 ) return false;
+                ip = ipToLong(element);
                 diff.add(deviceIpAddress - ip);
+            }
+            if (ip == -1) {
+                return false;
             }
         }
         return true;

--- a/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SystemFragment.java
@@ -119,16 +119,18 @@ public class SystemFragment extends BaseFragment {
         }
     }
 
+    private boolean checkElement(String s) {
+        return s.length() <= 15 && !s.contains(":");
+    }
+
     private boolean convertIp(String readMessage, long deviceIpAddress, ArrayList<Long> diff) {
         String[] array = readMessage.split(" ");
 
         for (String element : array) {
             //TODO: Need to convert IPv6 addresses to long; currently it is being skipped
-            if (element.length() <= 15 && !element.contains(":")) {
+            if (checkElement(element)) {
                 long ip = ipToLong(element);
-                if (ip == -1 ) {
-                    return false;
-                }
+                if (ip == -1 ) return false;
                 diff.add(deviceIpAddress - ip);
             }
         }


### PR DESCRIPTION
# Fixes #662 
Error Given:
```
java.lang.NumberFormatException: 
  at java.lang.Integer.parseInt (Integer.java:615)
  at java.lang.Integer.parseInt (Integer.java:650)
  at io.treehouses.remote.Fragments.SystemFragment.ipToLong (SystemFragment.java:131)
  at io.treehouses.remote.Fragments.SystemFragment.convertIp (SystemFragment.java:119)
  at io.treehouses.remote.Fragments.SystemFragment.checkSubnet (SystemFragment.java:109)
  at io.treehouses.remote.Fragments.SystemFragment.checkAndPrefilIp (SystemFragment.java:77)
  at io.treehouses.remote.Fragments.SystemFragment.access$200 (SystemFragment.java:33)
  at io.treehouses.remote.Fragments.SystemFragment$1.handleMessage (SystemFragment.java:193)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7356)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:930)
```

## Fixes by:
- Make sure that the IP address isn't a shortened ipV6 address
- Output carried over from other fragments running commands cause the command to be re-sent and checked again. Occurs when switching between fragments quickly (between home and System fragments)

