### PR TITLE
home: no null pointer in network profiles (fixes #663)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.java
@@ -113,6 +113,7 @@ public class HomeFragment extends BaseHomeFragment implements SetDisconnect {
     }
 
     private void switchProfile(NetworkProfile networkProfile) {
+        if (networkProfile == null) return;
         progressDialog = ProgressDialog.show(getContext(), "Connecting...", "Switching to " + networkProfile.ssid, true);
         progressDialog.show();
 


### PR DESCRIPTION
# Fixes #663 

Error:
```
java.lang.NullPointerException: 
  at io.treehouses.remote.Fragments.HomeFragment.switchProfile (HomeFragment.java:116)
  at io.treehouses.remote.Fragments.HomeFragment.readMessage (HomeFragment.java:293)
  at io.treehouses.remote.Fragments.HomeFragment.access$500 (HomeFragment.java:49)
  at io.treehouses.remote.Fragments.HomeFragment$4.handleMessage (HomeFragment.java:318)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7356)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:930)
```

## Fix
- Occurs when switching from Network Fragment to HomeFragment quickly; Output is carried over, and then results in a null Network Profile
- Check if null, and return
