### PR TITLE
home: no version code crash

### DIFF
--- a/app/src/main/java/io/treehouses/remote/utils/VersionUtils.java
+++ b/app/src/main/java/io/treehouses/remote/utils/VersionUtils.java
@@ -7,8 +7,13 @@ import android.content.pm.PackageManager;
 public class VersionUtils {
     public static int getVersionCode(Context context) {
         try {
-            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            return pInfo.versionCode;
+            if (context != null) {
+                PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+                return pInfo.versionCode;
+            }
+            else {
+                return -1;
+            }
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
         }
@@ -16,8 +21,13 @@ public class VersionUtils {
     }
     public static String getVersionName(Context context) {
         try {
-            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            return pInfo.versionName;
+            if (context != null) {
+                PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+                return pInfo.versionName;
+            }
+            else {
+                return "ERROR";
+            }
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
```
java.lang.NullPointerException: 
  at io.treehouses.remote.utils.VersionUtils.getVersionCode (VersionUtils.java:10)
  at io.treehouses.remote.Network.ParseDbService.sendLog (ParseDbService.java:23)
  at io.treehouses.remote.bases.BaseHomeFragment.sendLog (BaseHomeFragment.java:112)
  at io.treehouses.remote.bases.BaseHomeFragment.checkImageInfo (BaseHomeFragment.java:97)
  at io.treehouses.remote.Fragments.HomeFragment.readMessage (HomeFragment.java:288)
  at io.treehouses.remote.Fragments.HomeFragment.access$500 (HomeFragment.java:49)
  at io.treehouses.remote.Fragments.HomeFragment$4.handleMessage (HomeFragment.java:323)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:213)
  at android.app.ActivityThread.main (ActivityThread.java:8147)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1101)
```

## Fix:
Check for null context before trying to get the version code/ version name