### PR TITLE
settings: add alertdialog before clear/reset (fixes #618)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
@@ -1,5 +1,7 @@
 package io.treehouses.remote.Fragments;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
@@ -11,6 +13,11 @@ import io.treehouses.remote.R;
 import io.treehouses.remote.utils.SaveUtils;
 
 public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceClickListener {
+    private static final int CLEAR_COMMANDS_ID = 1;
+    private static final int RESET_COMMANDS_ID = 2;
+    private static final int NETWORK_PROFILES_ID = 3;
+
+
     public SettingsFragment() {
 
     }
@@ -43,19 +50,63 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
     public boolean onPreferenceClick(Preference preference) {
         switch (preference.getKey()) {
             case "clear_commands":
+                clearCommands();
+                break;
+            case "reset_commands":
+                resetCommands();
+                break;
+            case "network_profiles":
+                networkProfiles();
+                break;
+        }
+        return false;
+    }
+
+    private void clearCommands() {
+        createAlertDialog("Clear Commands List", "Would you like to completely clear the commands list that is found in terminal? ", "Clear",  CLEAR_COMMANDS_ID);
+    }
+
+    private void resetCommands() {
+        createAlertDialog("Reset Commands List", "Would you like to reset the command list to the default commands? ", "Reset", RESET_COMMANDS_ID);
+    }
+
+    private void networkProfiles() {
+        createAlertDialog("Reset Network Profiles", "Would you like to remove all network profiles? ", "Clear", NETWORK_PROFILES_ID);
+
+    }
+    private void createAlertDialog(String title, String message, String positive, int ID) {
+        new AlertDialog.Builder(getContext())
+                .setTitle(title)
+                .setMessage(message)
+                .setPositiveButton(positive, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        onClickDialog(ID);
+                    }
+                })
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                    }
+                })
+                .create()
+                .show();
+    }
+    private void onClickDialog(int id) {
+        switch (id) {
+            case CLEAR_COMMANDS_ID:
                 SaveUtils.clearCommandsList(getContext());
                 Toast.makeText(getContext(), "Commands List has been Cleared", Toast.LENGTH_LONG).show();
                 break;
-            case "reset_commands":
+            case RESET_COMMANDS_ID:
                 SaveUtils.clearCommandsList(getContext());
                 SaveUtils.initCommandsList(getContext());
                 Toast.makeText(getContext(), "Commands has been reset to default", Toast.LENGTH_LONG).show();
                 break;
-            case "network_profiles":
+            case NETWORK_PROFILES_ID:
                 SaveUtils.clearProfiles(getContext());
                 Toast.makeText(getContext(), "Network Profiles have been reset", Toast.LENGTH_LONG).show();
                 break;
         }
-        return false;
     }
 }

--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.java
@@ -67,11 +67,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
     }
 
     private void resetCommands() {
-        createAlertDialog("Reset Commands List", "Would you like to reset the command list to the default commands? ", "Reset", RESET_COMMANDS_ID);
+        createAlertDialog("Default Commands List", "Would you like to reset the command list to the default commands? ", "Reset", RESET_COMMANDS_ID);
     }
 
     private void networkProfiles() {
-        createAlertDialog("Reset Network Profiles", "Would you like to remove all network profiles? ", "Clear", NETWORK_PROFILES_ID);
+        createAlertDialog("Clear Network Profiles", "Would you like to remove all network profiles? ", "Clear", NETWORK_PROFILES_ID);
 
     }
     private void createAlertDialog(String title, String message, String positive, int ID) {


### PR DESCRIPTION
# Fixes #618 

# Features
- Added dialog before clearing commands list, resetting commands list to d3efault, and before clearing network profiles.

# Screenshots
<img width="436" alt="Screen Shot 2020-03-13 at 10 10 05 PM" src="https://user-images.githubusercontent.com/37857112/76673041-00ac6380-6578-11ea-809b-b94dd5c0e50d.png">
<img width="436" alt="Screen Shot 2020-03-13 at 10 09 56 PM" src="https://user-images.githubusercontent.com/37857112/76673042-0144fa00-6578-11ea-9e72-0b14ecee283b.png">
<img width="436" alt="Screen Shot 2020-03-13 at 10 09 45 PM" src="https://user-images.githubusercontent.com/37857112/76673043-0144fa00-6578-11ea-8d7c-9bae8fc332ba.png">

