### PR TITLE
network: no leading space from search dialog (fixes #677)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/WifiDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/WifiDialogFragment.java
@@ -90,7 +90,7 @@ public class WifiDialogFragment extends DialogFragment {
                 return;
             }
             Intent intent = new Intent();
-            intent.putExtra(WIFI_SSID_KEY, SSID);
+            intent.putExtra(WIFI_SSID_KEY, SSID.trim());
             getTargetFragment().onActivityResult(getTargetRequestCode(), Activity.RESULT_OK, intent);
             wifiList.clear();
             dismiss();


### PR DESCRIPTION
# Fixes #677 

`SSID.trim()`