### PR TITLE
bluetooth stack refactor (fixes #548)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
@@ -243,9 +243,7 @@ public class RPIDialogFragment extends BaseDialogFragment {
             Log.e("RPIDialogFragment", "" + msg.what);
             String readMessage = (String) msg.obj;
 
-            if (!TextUtils.isEmpty(readMessage) && readMessage.equals("connectionCheck")) {
-                pDialog.dismiss();
-            }
+            if (!TextUtils.isEmpty(readMessage) && readMessage.equals("connectionCheck")) pDialog.dismiss();
 
             switch (msg.what) {
                 case Constants.MESSAGE_STATE_CHANGE:

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.java
@@ -259,6 +259,8 @@ public class RPIDialogFragment extends BaseDialogFragment {
                             Toast.makeText(context, "Bluetooth Connected", LENGTH_LONG).show();
                             break;
                         case Constants.STATE_NONE:
+                            pDialog.dismiss();
+                            Toast.makeText(context, "Connection Failed: Please Try Again", LENGTH_LONG).show();
                             Log.e("RPIDialogFragment", "Bluetooth Connection Status Change: State None");
                             break;
                     }


### PR DESCRIPTION
# Fixes #548

## Realizations for Improvements
- There is no need for the ability of an *insecure* Bluetooth connection. **Bluetooth 2.1** devices and above all require secure connections, and all versions of Raspberry Pi have a greater version than 2.1.
- The phone does *not need to accept* Bluetooth connections from other devices. The phone only needs to connect to the Raspberry Pi, and not receive connections.

`E/BluetoothChatService: Socket Type: Insecure accept() failedjava.io.IOException: read failed, socket might closed or timeout, read ret: -1`

This line was only being called if accepting a connection from another device. Since there was no need to look for incoming connections, the AcceptThread has been commented out.

## Changes
- Commented out the AcceptThread
- Remove all code for insecure Bluetooth Connections

## Performance Changes
- In earlier versions, repeated connections to the Raspberry Pi would cause a failure to connect again to the device, unless the app was restarted. This was solved.
- Faster connection times

This has been working on my Google Pixel/ Raspberry Pi 4B+ well. Please test this to make sure it works on all devices/ Raspberry Pi's.
