### PR TITLE
about: redesign (fixes #508)

### DIFF
--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -31,7 +31,7 @@
             android:id="@+id/textView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="30dp"
             android:gravity="center"
             android:padding="@dimen/padding_normal"
             android:text="@string/initial_textview"
@@ -43,7 +43,7 @@
 
         <Button
             android:id="@+id/btn_image"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/padding_normal"
             android:layout_marginLeft="@dimen/padding_normal"
@@ -63,7 +63,7 @@
 
         <Button
             android:id="@+id/btn_gitter"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/padding_normal"
             android:layout_marginLeft="@dimen/padding_normal"
@@ -80,7 +80,7 @@
 
         <Button
             android:id="@+id/btn_contributors"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="8dp"
@@ -99,7 +99,7 @@
 
         <Button
             android:id="@+id/btn_github"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/padding_normal"
             android:layout_marginLeft="@dimen/padding_normal"
@@ -116,7 +116,7 @@
 
         <Button
             android:id="@+id/btn_version"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginLeft="8dp"

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -43,7 +43,7 @@
 
         <Button
             android:id="@+id/btn_image"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/padding_normal"
             android:layout_marginLeft="@dimen/padding_normal"
@@ -53,10 +53,8 @@
             android:background="@color/colorPrimary"
             android:paddingLeft="@dimen/margin_medium"
             android:paddingRight="@dimen/margin_medium"
-            
             android:text="Treehouses Image"
             android:textColor="@color/bg_white"
-            android:textSize="@dimen/text_size_mid"
             app:layout_constraintBottom_toTopOf="@+id/btn_version"
             app:layout_constraintEnd_toStartOf="@+id/btn_gitter"
             app:layout_constraintStart_toEndOf="@+id/btn_github" />
@@ -73,7 +71,7 @@
             android:text="gitter"
             android:textColor="@color/bg_white"
             android:gravity="center"
-            android:textSize="@dimen/text_size_mid"
+            android:textSize="@dimen/text_size_small"
             app:layout_constraintBaseline_toBaselineOf="@+id/btn_image"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/btn_image" />
@@ -109,7 +107,7 @@
             android:background="@color/colorPrimary"
             android:text="GitHub"
             android:textColor="@color/bg_white"
-            android:textSize="@dimen/text_size_mid"
+            android:textSize="@dimen/text_size_small"
             app:layout_constraintBaseline_toBaselineOf="@+id/btn_image"
             app:layout_constraintEnd_toStartOf="@+id/btn_image"
             app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
Fixes #508

<img width="1440" alt="Screenshot 2020-04-25 at 10 11 52 AM" src="https://user-images.githubusercontent.com/4152386/80268896-d5bc4000-86dd-11ea-8a7d-8b508c28f4b0.png">

Issues:

1) Left side 1st device (treehouses img) button text requires 10sp in order for text to fit.

2) The left 2 devices font size are referenced from the values/dimen, so making the 1st device font smaller will cause 2nd device (treehouses img) button text to be smaller. 


