### PR TITLE
terminal: toast instead of overflow

### DIFF
--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -216,6 +216,10 @@ public class BaseTerminalFragment extends BaseFragment{
         return stringBuilder.toString();
     }
     protected void updateArrayAdapters(CommandsList data) {
+        if (data.commands == null) {
+            Toast.makeText(requireContext(), "Error has occurred. Please Refresh", Toast.LENGTH_SHORT).show();
+            return;
+        }
         for (int i = 0;i < data.commands.size();i++) {
             String s = getRootCommand(data.commands.get(i)).trim();
             Log.d("TAG", "updateArrayAdapters: "+s);


### PR DESCRIPTION
### Steps to reproduce
1. Go to services
2. Before JSON response is received, switch to terminal

### Problem
- GSON json to java class not successful (wrong JSON output received)

### Fix
- Check if null, and if so, alert user