### PR TITLE
services: catch null pointer on wrong json

### DIFF
--- a/app/src/main/java/io/treehouses/remote/bases/BaseServicesFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseServicesFragment.java
@@ -75,6 +75,10 @@ public class BaseServicesFragment extends BaseFragment {
     }
 
     private void constructServiceList(ServicesData servicesData, ArrayList<ServiceInfo> services) {
+        if (servicesData == null || servicesData.getAvailable() == null) {
+            Toast.makeText(getContext(), "Error Occurred. Please Refresh", Toast.LENGTH_SHORT).show();
+            return;
+        }
         services.clear();
         for (String service : servicesData.getAvailable()) {
             if (inServiceList(service, services) == -1) {


### PR DESCRIPTION
On rare occasions, when switching quickly between terminal and services, the wrong json getting received by the services fragment.

Similar to #747 , however, instead of guarding the terminal, this PR guards the services fragment.