### PR TITLE
home: no strange logs (fixes #779)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.kt
@@ -161,9 +161,13 @@ class HomeFragment : BaseHomeFragment(), SetDisconnect {
             connectionState = true
             checkVersionSent = true
             writeToRPI("""treehouses remote version ${BuildConfig.VERSION_CODE}""".trimIndent())
+            if (!MainApplication.logSent) {
+                writeToRPI("treehouses remote check\n")
+            }
         } else {
             transitionDisconnected()
             connectionState = false
+            MainApplication.logSent = false
         }
         mChatService.updateHandler(mHandler)
     }
@@ -223,7 +227,8 @@ class HomeFragment : BaseHomeFragment(), SetDisconnect {
             //CLI Needs Upgrade
             showUpgradeCLI()
         } else if (BuildConfig.VERSION_CODE == 2 || output.contains("true")) {
-            writeToRPI("treehouses remote check\n")
+            listener.sendMessage("treehouses internet\n")
+            internetSent = true
         } else if (output.contains("false")) {
             val alertDialog = AlertDialog.Builder(context)
                     .setTitle("Update Required")
@@ -252,10 +257,8 @@ class HomeFragment : BaseHomeFragment(), SetDisconnect {
             internetSent = false
         } else if (output.startsWith("version: ") || checkVersionSent) {
             checkVersion(output)
-        } else if (output.contains(" ") && output.trim().split(" ").size == 4 && !matchResult(output, "pirateship", "bridge") && !output.contains("network")) {
+        } else if (output.contains(" ") && output.trim().split(" ").size == 4 && !MainApplication.logSent) {
             checkImageInfo(output.trim().split(" "), mChatService.connectedDeviceName)
-            listener.sendMessage("treehouses internet\n")
-            internetSent = true
         } else if (internetSent) {
             internetSent = false
             if (output.trim { it <= ' ' }.contains("true")) internetstatus!!.setImageDrawable(resources.getDrawable(R.drawable.circle_green)) else internetstatus!!.setImageDrawable(resources.getDrawable(R.drawable.circle))

--- a/app/src/main/java/io/treehouses/remote/MainApplication.kt
+++ b/app/src/main/java/io/treehouses/remote/MainApplication.kt
@@ -35,5 +35,7 @@ class MainApplication : Application() {
         @JvmField
         var ratingDialog = true
 
+        var logSent = false
+
     }
 }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseHomeFragment.kt
@@ -101,6 +101,7 @@ open class BaseHomeFragment : BaseFragment() {
             map["bluetoothMacAddress"] = bluetoothMac
             map["rpiVersion"] = rpiVersion
             ParseDbService.sendLog(activity, deviceName, map, preferences)
+            MainApplication.logSent = true
         }
     }
 


### PR DESCRIPTION
# Fixes #779 
### Issues
1. Logs were being sent onResume of Homefragment, causing block of logs per connection.
2. Strange outputs were caused by the overflow output from other fragments (namely Services Fragment). To reproduce strange logs, switch from Services Fragment back to the HomeFragment before the output has been received.
### Fix
Added boolean to mainApplication to manage logsent state.

