### PR TITLE
network: improve visibility of dialogs

### DIFF
--- a/app/src/main/java/io/treehouses/remote/bases/BaseBottomSheetDialog.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseBottomSheetDialog.java
@@ -1,16 +1,27 @@
 package io.treehouses.remote.bases;
 
+import android.app.Dialog;
 import android.content.Context;
+import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
 
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
+import io.treehouses.remote.R;
 import io.treehouses.remote.callback.HomeInteractListener;
 
 public class BaseBottomSheetDialog extends BottomSheetDialogFragment {
     protected Context context;
     protected HomeInteractListener listener;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        setStyle(DialogFragment.STYLE_NORMAL, R.style.DialogStyle);
+        return super.onCreateDialog(savedInstanceState);
+    }
 
     @Override
     public void onAttach(@NonNull Context c) {
@@ -22,4 +33,6 @@ public class BaseBottomSheetDialog extends BottomSheetDialogFragment {
             throw new ClassCastException(c.toString() + " must implement HomeInteractListener");
         }
     }
+
+
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -127,4 +127,8 @@
         <item name="android:textColor">@color/bg_white</item>
     </style>
 
+    <style name="DialogStyle" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
 </resources>


### PR DESCRIPTION
Move the `bottomsheetdialog` up a bit; improves the ability to type. 

## Before
<img width="440" alt="Screen Shot 2020-05-29 at 8 46 56 PM" src="https://user-images.githubusercontent.com/37857112/83315394-b2f5dd80-a1ed-11ea-818b-ad9def45dc54.png">

## After
<img width="440" alt="Screen Shot 2020-05-29 at 8 44 42 PM" src="https://user-images.githubusercontent.com/37857112/83315404-b9845500-a1ed-11ea-8c1d-7b2edfe2b3d8.png">

And user can move the bottom sheet dialog up if they wish to see more.
<img width="440" alt="Screen Shot 2020-05-29 at 8 45 07 PM" src="https://user-images.githubusercontent.com/37857112/83315407-bb4e1880-a1ed-11ea-9b4b-a7e428da56e3.png">
