### PR TITLE
terminal: add help menu (fixes #745)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         //Uncomment for debugging
-        debug {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+//        debug {
+//            minifyEnabled true
+//            shrinkResources true
+//            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+//        }
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         //Uncomment for debugging
-//        debug {
-//            minifyEnabled true
-//            shrinkResources true
-//            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-//        }
+        debug {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
     lintOptions {
         abortOnError false

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -1,0 +1,80 @@
+package io.treehouses.remote.Fragments.DialogFragments
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.os.Bundle
+import android.os.Handler
+import android.os.Message
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import io.treehouses.remote.Constants
+import io.treehouses.remote.R
+import io.treehouses.remote.bases.BaseDialogFragment
+import io.treehouses.remote.databinding.DialogHelpBinding
+import io.treehouses.remote.utils.RESULTS
+import io.treehouses.remote.utils.match
+
+
+class HelpDialog : BaseDialogFragment() {
+    lateinit var bind: DialogHelpBinding
+    var jsonString = ""
+    var jsonReceiving = false
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        bind = DialogHelpBinding.inflate(inflater, container, false)
+        listener.chatService.updateHandler(mHandler)
+        listener.sendMessage(getString(R.string.TREEHOUSES_HELP_JSON))
+        jsonReceiving = true
+        bind.progressBar.visibility = View.VISIBLE
+        return bind.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bind.closeButton.setOnClickListener { dismiss() }
+
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (dialog != null) {
+            dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        }
+    }
+
+    private val mHandler: Handler = @SuppressLint("HandlerLeak")
+    object : Handler() {
+        override fun handleMessage(msg: Message) {
+            if (msg.what == Constants.MESSAGE_READ) {
+                val output = msg.obj as String
+                if (output.isNotEmpty()) readMessage(output)
+
+            }
+        }
+    }
+
+    private fun readMessage(output: String) {
+        when {
+            jsonReceiving -> jsonString += output
+            jsonReceiving && jsonString.trim().endsWith("\" }") -> {
+                jsonReceiving = false
+                bind.progressBar.visibility = View.GONE
+            }
+            match(output) == RESULTS.START_JSON -> {
+                Log.d("JSON", output)
+                jsonString = ""
+                jsonReceiving = true
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -37,10 +37,10 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
         bind.searchBar.isIconifiedByDefault = false
         bind.results.addOnItemTouchListener(RecyclerViewClickListener(context, bind.results, object: RecyclerViewClickListener.ClickListener {
             override fun onClick(view: View?, position: Int) {
-                fullTransitionDescription((bind.results.adapter as HelpAdapter).getitem(position))
+                fullTransitionDescription(getItemAtPosition(position))
             }
             override fun onLongClick(view: View?, position: Int) {
-                transitionDescription((bind.results.adapter as HelpAdapter).getitem(position))
+                transitionDescription(getItemAtPosition(position))
             }
         }))
 
@@ -48,8 +48,10 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
 
         jsonString = arguments?.getString("jsonString")!!
         createJson(jsonString)
+    }
 
-
+    fun getItemAtPosition(pos: Int): HelpCommand {
+        return (bind.results.adapter as HelpAdapter).getitem(pos)
     }
 
     private fun fullTransitionDescription(item: HelpCommand) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -63,14 +63,18 @@ class HelpDialog : BaseDialogFragment() {
     }
 
     private fun readMessage(output: String) {
+        if (jsonReceiving) {
+            jsonString += output
+        }
+        Log.e("WHAT", jsonString.takeLast(500) + "|")
         when {
-            jsonReceiving -> jsonString += output
-            jsonReceiving && jsonString.trim().endsWith("\" }") -> {
+            jsonReceiving && jsonString.trim().endsWith("\" } ") -> {
                 jsonReceiving = false
+                jsonString += output
                 bind.progressBar.visibility = View.GONE
+                Log.e("HERE", "WE HERE")
             }
             match(output) == RESULTS.START_JSON -> {
-                Log.d("JSON", output)
                 jsonString = ""
                 jsonReceiving = true
             }

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -34,6 +34,7 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
             adapter = HelpAdapter()
         }
         bind.searchBar.setOnQueryTextListener(this)
+        bind.searchBar.isIconifiedByDefault = false
         bind.results.addOnItemTouchListener(RecyclerViewClickListener(context, bind.results, object: RecyclerViewClickListener.ClickListener {
             override fun onClick(view: View?, position: Int) {
                 val item = (bind.results.adapter as HelpAdapter).getitem(position)

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -37,13 +37,14 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
         bind.searchBar.isIconifiedByDefault = false
         bind.results.addOnItemTouchListener(RecyclerViewClickListener(context, bind.results, object: RecyclerViewClickListener.ClickListener {
             override fun onClick(view: View?, position: Int) {
-                val item = (bind.results.adapter as HelpAdapter).getitem(position)
-                transitionDescription(item)
+                fullTransitionDescription((bind.results.adapter as HelpAdapter).getitem(position))
             }
-            override fun onLongClick(view: View?, position: Int) {}
+            override fun onLongClick(view: View?, position: Int) {
+                transitionDescription((bind.results.adapter as HelpAdapter).getitem(position))
+            }
         }))
 
-        bind.backButton.setOnClickListener { transitionSearch() }
+        bind.backButton.setOnClickListener { fullTransitionSearch() }
 
         jsonString = arguments?.getString("jsonString")!!
         createJson(jsonString)
@@ -51,21 +52,26 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
 
     }
 
-    private fun transitionDescription(item: HelpCommand) {
+    private fun fullTransitionDescription(item: HelpCommand) {
         bind.results.visibility = View.GONE
         bind.searchBar.visibility = View.GONE
-        bind.showHelp.visibility = View.VISIBLE
         bind.backButton.visibility = View.VISIBLE
-        bind.titleDescription.text = item.title
-        bind.description.text = item.preview
+
+        transitionDescription(item)
     }
 
-    private fun transitionSearch() {
+    private fun fullTransitionSearch() {
         bind.results.visibility = View.VISIBLE
         bind.searchBar.visibility = View.VISIBLE
         bind.showHelp.visibility = View.GONE
         bind.backButton.visibility = View.GONE
     }
+    private fun transitionDescription(item: HelpCommand) {
+        bind.showHelp.visibility = View.VISIBLE
+        bind.titleDescription.text = item.title
+        bind.description.text = item.preview
+    }
+
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog: Dialog = super.onCreateDialog(savedInstanceState)
@@ -75,9 +81,7 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
 
     override fun onStart() {
         super.onStart()
-        if (dialog != null) {
-            dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-        }
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
 
     private fun createJson(jsonStr: String) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -85,6 +85,7 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
             (bind.results.adapter as HelpAdapter).add(HelpCommand(it, obj.get(it) as String))
             items.add(HelpCommand(it, obj.get(it) as String))
         }
+        bind.progressBar.visibility = View.GONE
     }
 
     override fun onQueryTextSubmit(query: String?): Boolean {

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -3,10 +3,12 @@ package io.treehouses.remote.Fragments;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,7 +67,6 @@ public class TerminalFragment extends BaseTerminalFragment {
 
     private static boolean isRead = false;
 
-    private boolean jsonSent, jsonReceiving = false;
     private String jsonString = "";
 
     private ActivityTerminalFragmentBinding bind;
@@ -177,6 +178,12 @@ public class TerminalFragment extends BaseTerminalFragment {
                 bind.editTextOut.setText(last);
                 bind.editTextOut.setSelection(bind.editTextOut.length());
             } catch (Exception e) { e.printStackTrace(); } });
+
+        bind.infoButton.setOnClickListener(v -> {
+            listener.sendMessage(getString(R.string.TREEHOUSES_HELP_JSON));
+            jsonSent = true;
+        });
+
     }
 
     @Override
@@ -245,10 +252,15 @@ public class TerminalFragment extends BaseTerminalFragment {
 
     private void handleJson(String readMessage) {
         if (jsonReceiving) {
-            jsonString += readMessage.trim();
-            if (jsonString.endsWith("]}")) {
-                jsonString += readMessage.trim();
+            jsonString += readMessage;
+            if (jsonString.trim().endsWith("]}")) {
                 buildJSON();
+                jsonReceiving = false;
+                jsonSent = false;
+            }
+            else if (jsonString.trim().endsWith("\" }")) {
+                Log.e("SHOWING", "HELP with "+ jsonString);
+                showHelpDialog();
                 jsonReceiving = false;
                 jsonSent = false;
             }
@@ -256,6 +268,14 @@ public class TerminalFragment extends BaseTerminalFragment {
             jsonReceiving = true;
             jsonString = readMessage.trim();
         }
+    }
+    private void showHelpDialog() {
+        Bundle b = new Bundle();
+        b.putString("jsonString", jsonString);
+        DialogFragment dialogFrag = new HelpDialog();
+        dialogFrag.setTargetFragment(this, Constants.REQUEST_DIALOG_FRAGMENT);
+        dialogFrag.setArguments(b);
+        dialogFrag.show(this.requireActivity().getSupportFragmentManager().beginTransaction(), "helpDialog");
     }
 
     /**

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -112,9 +112,7 @@ public class TerminalFragment extends BaseTerminalFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
-        setUpAutoComplete(bind.editTextOut);
-    }
+    public void onViewCreated(View view, Bundle savedInstanceState) { setUpAutoComplete(bind.editTextOut); }
 
     @Override
     public void onDestroy() {
@@ -135,8 +133,6 @@ public class TerminalFragment extends BaseTerminalFragment {
         super.onResume();
         setupChat();
     }
-
-    public static TerminalFragment getInstance() { return instance; }
 
     private ArrayAdapter<String> getmConversationArrayAdapter() { return mConversationArrayAdapter; }
 
@@ -213,10 +209,7 @@ public class TerminalFragment extends BaseTerminalFragment {
 
     protected void onResultCaseEnable(int resultCode) {
         // When the request to enable Bluetooth returns
-        if (resultCode == Activity.RESULT_OK) {
-            // Bluetooth is now enabled, so set up a chat session
-            setupChat();
-        } else {
+        if (resultCode == Activity.RESULT_OK) { setupChat(); } else {
             // User did not enable Bluetooth or an error occurred
             Toast.makeText(getActivity(), R.string.bt_not_enabled_leaving, Toast.LENGTH_SHORT).show();
             getActivity().finish();
@@ -249,8 +242,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         try {
             JSONObject jsonObject = new JSONObject(jsonString);
             commands = new Gson().fromJson(jsonObject.toString(), CommandsList.class);
-            if (commands != null) updateArrayAdapters(commands);
-        } catch (JSONException e) { e.printStackTrace(); }
+            if (commands != null) updateArrayAdapters(commands); } catch (JSONException e) { e.printStackTrace(); }
     }
 
     private void handleJson(String readMessage) {
@@ -261,7 +253,6 @@ public class TerminalFragment extends BaseTerminalFragment {
                 jsonSend(false);
             }
             else if (jsonString.trim().endsWith("\" }")) {
-                Log.e("SHOWING", "HELP with "+ jsonString);
                 showHelpDialog(jsonString);
                 helpJsonString = jsonString;
                 jsonSend(false);
@@ -272,15 +263,10 @@ public class TerminalFragment extends BaseTerminalFragment {
         }
     }
     private void jsonSend(boolean sent) {
-        if (sent) {
-            bind.progressBar.setVisibility(View.VISIBLE);
-            jsonSent = true;
-        }
-        else {
-            bind.progressBar.setVisibility(View.GONE);
-            jsonReceiving = false;
-            jsonSent =false;
-        }
+        jsonSent = sent;
+        if (sent) { bind.progressBar.setVisibility(View.VISIBLE); }
+        else { bind.progressBar.setVisibility(View.GONE);
+            jsonReceiving = false; }
     }
     private void showHelpDialog(String jsonString) {
         Bundle b = new Bundle();

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,10 +45,8 @@ public class TerminalFragment extends BaseTerminalFragment {
     private static final String TITLE_EXPANDABLE = "Commands";
     private static TerminalFragment instance = null;
     private ExpandableListAdapter expandableListAdapter;
-    private ArrayList<String> list;
     private CommandsList commands;
     private int i;
-    private String last;
     private List<String> expandableListTitle;
     private HashMap<String, List<CommandListItem>> expandableListDetail;
 
@@ -168,8 +165,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         });
         bind.btnPrevious.setOnClickListener(v -> {
             try {
-                last = list.get(--i);
-                bind.editTextOut.setText(last);
+                if (i >= 0) bind.editTextOut.setText(MainApplication.getCommandList().get(--i).trim());
                 bind.editTextOut.setSelection(bind.editTextOut.length());
             } catch (Exception e) { e.printStackTrace(); } });
 
@@ -224,8 +220,7 @@ public class TerminalFragment extends BaseTerminalFragment {
 
     private void addToCommandList(String writeMessage) {
         MainApplication.getCommandList().add(writeMessage);
-        list = MainApplication.getCommandList();
-        i = list.size();
+        i = MainApplication.getCommandList().size();
     }
     private void onResultCaseDialogChpass(int resultCode, Intent data) {
         if (resultCode == Activity.RESULT_OK) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -2,6 +2,7 @@ package io.treehouses.remote.Fragments;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -14,6 +15,7 @@ import android.widget.ExpandableListAdapter;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
 
 import com.google.gson.Gson;
 
@@ -27,6 +29,7 @@ import java.util.List;
 import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.DialogFragments.AddCommandDialogFragment;
 import io.treehouses.remote.Fragments.DialogFragments.ChPasswordDialogFragment;
+import io.treehouses.remote.Fragments.DialogFragments.HelpDialog;
 import io.treehouses.remote.MainApplication;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
@@ -84,6 +87,8 @@ public class TerminalFragment extends BaseTerminalFragment {
         return bind.getRoot();
     }
 
+
+
     public void setupList() {
         expandableListTitle = new ArrayList<>(expandableListDetail.keySet());
         expandableListAdapter = new CommandListAdapter(getContext(), expandableListTitle, expandableListDetail);
@@ -126,6 +131,7 @@ public class TerminalFragment extends BaseTerminalFragment {
     @Override
     public void onResume() {
         checkStatus(mChatService, bind.pingStatus, bind.PING);
+        onLoad(mHandler);
         super.onResume();
         setupChat();
     }

--- a/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TerminalFragment.java
@@ -161,8 +161,7 @@ public class TerminalFragment extends BaseTerminalFragment {
         // Initialize the send button with a listener that for click events
         bind.buttonSend.setOnClickListener(v -> {
             // Send a message using content of the edit text widget
-            View view = getView();
-            if (null != view) {
+            if (null != getView()) {
                 listener.sendMessage(bind.editTextOut.getText().toString());
                 bind.editTextOut.setText("");
             }

--- a/app/src/main/java/io/treehouses/remote/Views/HelpViewHolder.kt
+++ b/app/src/main/java/io/treehouses/remote/Views/HelpViewHolder.kt
@@ -1,0 +1,13 @@
+package io.treehouses.remote.Views
+
+import androidx.recyclerview.widget.RecyclerView
+import io.treehouses.remote.databinding.RowHelpBinding
+import io.treehouses.remote.pojo.HelpCommand
+
+class HelpViewHolder(binding: RowHelpBinding) : RecyclerView.ViewHolder(binding.root) {
+    private val mBinding: RowHelpBinding = binding
+    fun bind(data: HelpCommand) {
+        mBinding.helpCommand.text = data.title
+        mBinding.commandPreview.text = data.preview
+    }
+}

--- a/app/src/main/java/io/treehouses/remote/Views/HelpViewHolder.kt
+++ b/app/src/main/java/io/treehouses/remote/Views/HelpViewHolder.kt
@@ -8,6 +8,6 @@ class HelpViewHolder(binding: RowHelpBinding) : RecyclerView.ViewHolder(binding.
     private val mBinding: RowHelpBinding = binding
     fun bind(data: HelpCommand) {
         mBinding.helpCommand.text = data.title
-        mBinding.commandPreview.text = data.preview
+        mBinding.commandPreview.text = data.preview.trim()
     }
 }

--- a/app/src/main/java/io/treehouses/remote/Views/RecyclerViewClickListener.kt
+++ b/app/src/main/java/io/treehouses/remote/Views/RecyclerViewClickListener.kt
@@ -1,0 +1,42 @@
+package io.treehouses.remote.Views
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.MotionEvent
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
+
+class RecyclerViewClickListener(context: Context?, recyclerView: RecyclerView, private val clickListener: ClickListener?) : OnItemTouchListener {
+    private val gestureDetector: GestureDetector
+    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+        val child = rv.findChildViewUnder(e.x, e.y)
+        if (child != null && clickListener != null && gestureDetector.onTouchEvent(e)) {
+            clickListener.onClick(child, rv.getChildPosition(child))
+        }
+        return false
+    }
+
+    override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {}
+    override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+    interface ClickListener {
+        fun onClick(view: View?, position: Int)
+        fun onLongClick(view: View?, position: Int)
+    }
+
+    init {
+        gestureDetector = GestureDetector(context, object : SimpleOnGestureListener() {
+            override fun onSingleTapUp(e: MotionEvent): Boolean {
+                return true
+            }
+
+            override fun onLongPress(e: MotionEvent) {
+                val child = recyclerView.findChildViewUnder(e.x, e.y)
+                if (child != null && clickListener != null) {
+                    clickListener.onLongClick(child, recyclerView.getChildPosition(child))
+                }
+            }
+        })
+    }
+}

--- a/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
+++ b/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
@@ -1,0 +1,68 @@
+package io.treehouses.remote.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SortedList
+import io.treehouses.remote.Views.HelpViewHolder
+import io.treehouses.remote.databinding.RowHelpBinding
+import io.treehouses.remote.pojo.HelpCommand
+
+class HelpAdapter : RecyclerView.Adapter<HelpViewHolder>() {
+
+    private val sortedList: SortedList<HelpCommand> = SortedList(HelpCommand::class.java, object : SortedList.Callback<HelpCommand>() {
+        override fun areItemsTheSame(item1: HelpCommand?, item2: HelpCommand?): Boolean {
+            return item1?.title == item2?.title && item1?.preview == item2?.preview
+        }
+
+        override fun onMoved(fromPosition: Int, toPosition: Int) { notifyItemMoved(fromPosition, toPosition)}
+
+        override fun onChanged(position: Int, count: Int) { notifyItemRangeChanged(position, count) }
+
+        override fun onInserted(position: Int, count: Int) { notifyItemRangeInserted(position, count) }
+
+        override fun onRemoved(position: Int, count: Int) { notifyItemRangeRemoved(position, count) }
+
+        override fun compare(o1: HelpCommand, o2: HelpCommand): Int { return o1.title.compareTo(o2.title) }
+
+        override fun areContentsTheSame(oldItem: HelpCommand?, newItem: HelpCommand?): Boolean {
+            return oldItem?.title == newItem?.title && oldItem?.preview == newItem?.preview
+        }
+    })
+    fun add(model: HelpCommand?) { sortedList.add(model) }
+
+    fun remove(model: HelpCommand?) { sortedList.remove(model) }
+
+    fun add(models: List<HelpCommand>) { sortedList.addAll(models) }
+
+    fun getitem(position: Int) : HelpCommand { return sortedList.get(position) }
+
+    fun remove(models: List<HelpCommand?>) {
+        sortedList.beginBatchedUpdates()
+        for (model in models) sortedList.remove(model)
+        sortedList.endBatchedUpdates()
+    }
+
+    fun replaceAll(models: List<HelpCommand?>) {
+        sortedList.beginBatchedUpdates()
+        for (i in sortedList.size() - 1 downTo 0) {
+            val model: HelpCommand = sortedList.get(i)
+            if (!models.contains(model)) sortedList.remove(model)
+        }
+        sortedList.addAll(models)
+        sortedList.endBatchedUpdates()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HelpViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return HelpViewHolder(RowHelpBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: HelpViewHolder, position: Int) {
+        val value = sortedList.get(position)
+        holder.bind(value)
+    }
+
+    override fun getItemCount(): Int = sortedList.size()
+
+}

--- a/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
+++ b/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
@@ -11,9 +11,7 @@ import io.treehouses.remote.pojo.HelpCommand
 class HelpAdapter : RecyclerView.Adapter<HelpViewHolder>() {
 
     private val sortedList: SortedList<HelpCommand> = SortedList(HelpCommand::class.java, object : SortedList.Callback<HelpCommand>() {
-        override fun areItemsTheSame(item1: HelpCommand?, item2: HelpCommand?): Boolean {
-            return item1?.title == item2?.title && item1?.preview == item2?.preview
-        }
+        override fun areItemsTheSame(item1: HelpCommand?, item2: HelpCommand?): Boolean { return areSame(item1, item2) }
 
         override fun onMoved(fromPosition: Int, toPosition: Int) { notifyItemMoved(fromPosition, toPosition)}
 
@@ -25,10 +23,11 @@ class HelpAdapter : RecyclerView.Adapter<HelpViewHolder>() {
 
         override fun compare(o1: HelpCommand, o2: HelpCommand): Int { return o1.title.compareTo(o2.title) }
 
-        override fun areContentsTheSame(oldItem: HelpCommand?, newItem: HelpCommand?): Boolean {
-            return oldItem?.title == newItem?.title && oldItem?.preview == newItem?.preview
-        }
+        override fun areContentsTheSame(oldItem: HelpCommand?, newItem: HelpCommand?): Boolean { return areSame(oldItem, newItem) }
     })
+    private fun areSame(hC1: HelpCommand?, hC2: HelpCommand?) : Boolean {
+        return hC1?.title == hC2?.title && hC1?.preview == hC2?.preview
+    }
     fun add(model: HelpCommand?) { sortedList.add(model) }
 
     fun remove(model: HelpCommand?) { sortedList.remove(model) }

--- a/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
+++ b/app/src/main/java/io/treehouses/remote/adapter/HelpAdapter.kt
@@ -11,7 +11,9 @@ import io.treehouses.remote.pojo.HelpCommand
 class HelpAdapter : RecyclerView.Adapter<HelpViewHolder>() {
 
     private val sortedList: SortedList<HelpCommand> = SortedList(HelpCommand::class.java, object : SortedList.Callback<HelpCommand>() {
-        override fun areItemsTheSame(item1: HelpCommand?, item2: HelpCommand?): Boolean { return areSame(item1, item2) }
+        override fun areItemsTheSame(item1: HelpCommand?, item2: HelpCommand?): Boolean {
+            return item1?.title == item2?.title && item1?.preview == item2?.preview
+        }
 
         override fun onMoved(fromPosition: Int, toPosition: Int) { notifyItemMoved(fromPosition, toPosition)}
 
@@ -23,11 +25,9 @@ class HelpAdapter : RecyclerView.Adapter<HelpViewHolder>() {
 
         override fun compare(o1: HelpCommand, o2: HelpCommand): Int { return o1.title.compareTo(o2.title) }
 
-        override fun areContentsTheSame(oldItem: HelpCommand?, newItem: HelpCommand?): Boolean { return areSame(oldItem, newItem) }
+        override fun areContentsTheSame(oldItem: HelpCommand?, newItem: HelpCommand?): Boolean { return areItemsTheSame(oldItem, newItem) }
     })
-    private fun areSame(hC1: HelpCommand?, hC2: HelpCommand?) : Boolean {
-        return hC1?.title == hC2?.title && hC1?.preview == hC2?.preview
-    }
+
     fun add(model: HelpCommand?) { sortedList.add(model) }
 
     fun remove(model: HelpCommand?) { sortedList.remove(model) }

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -2,6 +2,7 @@ package io.treehouses.remote.bases;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
@@ -30,6 +31,7 @@ import java.util.Set;
 
 import io.treehouses.remote.Constants;
 import io.treehouses.remote.Fragments.DialogFragments.HelpDialog;
+import io.treehouses.remote.Fragments.TerminalFragment;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.pojo.CommandsList;
@@ -39,6 +41,8 @@ public class BaseTerminalFragment extends BaseFragment{
     private final String[] array2 = {"treehouses", "docker"};
     private Set<String> inSecondLevel, inThirdLevel;
     private ArrayAdapter<String> arrayAdapter1, arrayAdapter2, arrayAdapter3;
+    protected boolean jsonSent, jsonReceiving = false;
+
 
     public String handlerCaseWrite(String TAG, ArrayAdapter<String> mConversationArrayAdapter, Message msg) {
 
@@ -117,7 +121,7 @@ public class BaseTerminalFragment extends BaseFragment{
     }
     private boolean filterMessage(String readMessage) {
         boolean a = !readMessage.contains("1 packets") && !readMessage.contains("64 bytes") && !readMessage.contains("google.com") && !readMessage.contains("rtt") && !readMessage.trim().isEmpty();
-        boolean b = !readMessage.startsWith("treehouses ") && !readMessage.contains("treehouses remote commands");
+        boolean b = !readMessage.startsWith("treehouses ") && !readMessage.contains("treehouses remote commands") && !jsonSent;
         return a && b;
     }
 
@@ -152,11 +156,8 @@ public class BaseTerminalFragment extends BaseFragment{
     }
 
     private boolean isJson(String readMessage) {
-        try {
-            new JSONObject(readMessage);
-        } catch (JSONException ex) {
-            return false;
-        }
+        try { new JSONObject(readMessage);
+        } catch (JSONException ex) { return false; }
         return true;
     }
     private int countSpaces(String s) {
@@ -168,7 +169,7 @@ public class BaseTerminalFragment extends BaseFragment{
     protected void setUpAutoComplete(AutoCompleteTextView autoComplete) {
         inSecondLevel = new HashSet<>();
         inThirdLevel = new HashSet<>();
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(Objects.requireNonNull(getContext()));
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
         arrayAdapter1 = new ArrayAdapter<>(getContext(), android.R.layout.simple_dropdown_item_1line, array2);
         arrayAdapter2 = new ArrayAdapter<>(getContext(), android.R.layout.simple_dropdown_item_1line, new ArrayList<>());
         arrayAdapter3 = new ArrayAdapter<>(getContext(), android.R.layout.simple_dropdown_item_1line, new ArrayList<>());
@@ -234,9 +235,6 @@ public class BaseTerminalFragment extends BaseFragment{
                 inThirdLevel.add(data.commands.get(i));
             }
         }
-        DialogFragment dialogFrag = new HelpDialog();
-        dialogFrag.setTargetFragment(this, Constants.REQUEST_DIALOG_WIFI);
-        dialogFrag.show(this.requireActivity().getSupportFragmentManager().beginTransaction(), "wifiDialog");
     }
 
     private void addSpaces(AutoCompleteTextView autoComplete) {

--- a/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
+++ b/app/src/main/java/io/treehouses/remote/bases/BaseTerminalFragment.java
@@ -17,6 +17,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;
 
 import org.json.JSONException;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import io.treehouses.remote.Constants;
+import io.treehouses.remote.Fragments.DialogFragments.HelpDialog;
 import io.treehouses.remote.Network.BluetoothChatService;
 import io.treehouses.remote.R;
 import io.treehouses.remote.pojo.CommandsList;
@@ -232,6 +234,9 @@ public class BaseTerminalFragment extends BaseFragment{
                 inThirdLevel.add(data.commands.get(i));
             }
         }
+        DialogFragment dialogFrag = new HelpDialog();
+        dialogFrag.setTargetFragment(this, Constants.REQUEST_DIALOG_WIFI);
+        dialogFrag.show(this.requireActivity().getSupportFragmentManager().beginTransaction(), "wifiDialog");
     }
 
     private void addSpaces(AutoCompleteTextView autoComplete) {

--- a/app/src/main/java/io/treehouses/remote/pojo/HelpCommand.kt
+++ b/app/src/main/java/io/treehouses/remote/pojo/HelpCommand.kt
@@ -1,0 +1,3 @@
+package io.treehouses.remote.pojo
+
+data class HelpCommand(val title: String, val preview: String)

--- a/app/src/main/java/io/treehouses/remote/utils/CommandManager.kt
+++ b/app/src/main/java/io/treehouses/remote/utils/CommandManager.kt
@@ -22,10 +22,12 @@ enum class RESULTS {
     START_JSON,
     END_JSON_SERVICES,
     END_JSON_COMMANDS,
+    END_HELP
 }
 
 fun match (output: String) : RESULTS {
     when {
+        Matcher.isEndHelpJson(output) -> return RESULTS.END_HELP
         Matcher.isError(output) ->  return RESULTS.ERROR
         Matcher.isBoolean(output) -> return RESULTS.BOOLEAN
         Matcher.isVersion(output) -> return RESULTS.VERSION
@@ -40,16 +42,17 @@ fun match (output: String) : RESULTS {
         Matcher.isStartJSON(output) -> return RESULTS.START_JSON
         Matcher.isEndAllServicesJson(output) -> return RESULTS.END_JSON_SERVICES
         Matcher.isEndCommandsJson(output) -> return RESULTS.END_JSON_COMMANDS
-
     }
     return RESULTS.RESULT_NOT_FOUND
 }
 
+//Could remove IDs and simply use these functions
 object Matcher {
     private fun toLC(string: String) : String {return string.toLowerCase(Locale.ROOT).trim(); }
 
     fun isError(output: String): Boolean {
         val keys = listOf("error", "unknown", "usage", "command")
+        if (output.contains("{") || output.contains("}")) return false
         for (k in keys) if (toLC(output).contains(k)) return true
         return false
     }
@@ -88,8 +91,10 @@ object Matcher {
 
     fun isStartJSON(output: String): Boolean { return output.startsWith("{") }
 
-    fun isEndCommandsJson(output: String): Boolean { return output.endsWith("]}") }
+    fun isEndCommandsJson(output: String): Boolean { return toLC(output).endsWith("]}") }
 
-    fun isEndAllServicesJson(output: String): Boolean { return output.endsWith("}}") }
+    fun isEndAllServicesJson(output: String): Boolean { return toLC(output).endsWith("}}") }
+
+    fun isEndHelpJson(output: String): Boolean { return output.trim().endsWith("\" }")}
 
 }

--- a/app/src/main/res/drawable-anydpi/back_button.xml
+++ b/app/src/main/res/drawable-anydpi/back_button.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#585858"
+    android:alpha="0.6">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/help.xml
+++ b/app/src/main/res/drawable/help.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:height="50dp" android:tint="#585858"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="50dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_terminal_fragment.xml
+++ b/app/src/main/res/layout/activity_terminal_fragment.xml
@@ -57,6 +57,15 @@
         android:layout_margin="@dimen/margin_medium"
         android:background="@drawable/ic_history_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/infoButton" />
+
+    <Button
+        android:id="@+id/infoButton"
+        android:layout_width="@dimen/icon_size_mid"
+        android:layout_height="@dimen/icon_size_mid"
+        android:layout_margin="@dimen/margin_medium"
+        android:background="@drawable/help"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_terminal_fragment.xml
+++ b/app/src/main/res/layout/activity_terminal_fragment.xml
@@ -131,4 +131,14 @@
 
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_help.xml
+++ b/app/src/main/res/layout/dialog_help.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
     xmlns:tools="http://schemas.android.com/tools">
     <LinearLayout
         android:layout_width="match_parent"
@@ -44,9 +45,11 @@
                 android:id="@+id/title_description"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:textAlignment="center"
                 android:paddingBottom="@dimen/padding_normal"
                 tools:text="Command Title"
-                style="@style/TextAppearance.AppCompat.Light.SearchResult.Title"/>
+                style="@style/TextAppearance.AppCompat.Light.SearchResult.Title"
+                android:gravity="center_horizontal" />
             <ScrollView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">

--- a/app/src/main/res/layout/dialog_help.xml
+++ b/app/src/main/res/layout/dialog_help.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="@dimen/padding_normal"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+        <SearchView
+            android:id="@+id/search_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:queryHint="Search Commands"
+            app:defaultQueryHint="Search Commands"
+            />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/results"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_margin="@dimen/margin_large"
+            android:layout_weight="1"/>
+
+        <Button
+            android:id="@+id/closeButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_medium"
+            android:text="Close"/>
+
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_help.xml
+++ b/app/src/main/res/layout/dialog_help.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:padding="@dimen/padding_normal"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+        android:padding="@dimen/padding_normal">
         <SearchView
             android:id="@+id/search_bar"
             android:layout_width="match_parent"
@@ -17,19 +16,61 @@
             app:queryHint="Search Commands"
             app:defaultQueryHint="Search Commands"
             />
+        <Button
+            android:id="@+id/back_button"
+            android:background="@drawable/back_button"
+            android:layout_width="@dimen/icon_size_mid"
+            android:layout_height="@dimen/icon_size_mid"
+            style="@style/Widget.AppCompat.ActionButton"
+            android:visibility="gone"
+            />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/results"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_margin="@dimen/margin_large"
+            tools:listitem="@layout/row_help"
             android:layout_weight="1"/>
+
+        <LinearLayout
+            android:id="@+id/show_help"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:visibility="gone"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/title_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/padding_normal"
+                tools:text="Command Title"
+                style="@style/TextAppearance.AppCompat.Light.SearchResult.Title"/>
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <TextView
+                    android:id="@+id/description"
+                    android:padding="@dimen/padding_normal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="@tools:sample/lorem/random"/>
+            </ScrollView>
+
+        </LinearLayout>
 
         <Button
             android:id="@+id/closeButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/margin_medium"
-            android:text="Close"/>
+            android:text="Done"
+            android:textColor="@color/bg_white"
+            android:textSize="@dimen/text_size_mid"
+            android:background="@drawable/ic_connect_to_rpi"
+            android:textAllCaps="false"
+            />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/row_help.xml
+++ b/app/src/main/res/layout/row_help.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <TextView
+        android:id="@+id/help_command"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="@dimen/padding_normal"
+        android:paddingStart="@dimen/padding_normal"
+        android:paddingEnd="@dimen/padding_normal"
+        android:paddingRight="@dimen/padding_normal"
+        android:paddingTop="@dimen/padding_large"
+        tools:text="ITEM"
+        style="@style/TextAppearance.AppCompat"
+         />
+    <TextView
+        android:id="@+id/command_preview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="@dimen/padding_large"
+        android:paddingStart="@dimen/padding_large"
+        android:paddingRight="@dimen/padding_large"
+        android:paddingEnd="@dimen/padding_large"
+        android:maxLines="2"
+        tools:text="@tools:sample/lorem/random"
+        style="@style/TextAppearance.AppCompat.Caption"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/commands.xml
+++ b/app/src/main/res/values/commands.xml
@@ -18,5 +18,5 @@
     <string name="TREEHOUSES_BRIDGE">treehouses bridge \"%1$s\" \"%2$s\" \"%3$s\" \"%4$s\"\n</string>
     <string name="TREEHOUSES_ETHERNET">treehouses ethernet \"%1$s\" \"%2$s\" \"%3$s\" \"%4$s\"\n</string>
 
-
+    <string name="TREEHOUSES_HELP_JSON">treehouses remote help json\n</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 28 20:24:32 NPT 2019
+#Wed Jun 03 19:37:37 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
# Fixes #745 

## Features
- New Icon in Terminal
- Get JSON String from RPI with `treehouses remote help json`
- Filterable Command Search (Seaches major categories and within the help fields for text)
- RecyclerView
- Description of command

## Screenshots

<img width="438" alt="Screen Shot 2020-05-30 at 2 39 04 AM" src="https://user-images.githubusercontent.com/37857112/83321627-dd13c380-a21e-11ea-9003-7afb941b79bf.png">
<img width="437" alt="Screen Shot 2020-05-30 at 2 38 35 AM" src="https://user-images.githubusercontent.com/37857112/83321625-dc7b2d00-a21e-11ea-887e-eee94a79ebb9.png">
<img width="439" alt="Screen Shot 2020-05-30 at 2 38 55 AM" src="https://user-images.githubusercontent.com/37857112/83321626-dc7b2d00-a21e-11ea-8a2d-06deb9d28847.png">
^ Screen needs improvements in next iteration

---

### Added
- When an item is long clicked (finger held down on an item for extended period of time), a new view is visible, instead of the full screen description

<img width="439" alt="Screen Shot 2020-05-31 at 12 51 38 AM" src="https://user-images.githubusercontent.com/37857112/83344752-f37e5580-a2d8-11ea-9a50-076b5ab1b5dc.png">


## Possible Improvements:
- Improve design of Description of command
- Highlight Search phrase in description text and/or add search bar there as well
- Bold all commands within the text
- Improve spacing in places

## Tests Needed
- Try switching between fragments and see if any crashes occur
- Repeatedly click info button
- Anything is welcome!