### PR TITLE
possible fix for bluetooth connection Null Ptr (fixes #818)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Network/BluetoothChatService.java
+++ b/app/src/main/java/io/treehouses/remote/Network/BluetoothChatService.java
@@ -465,11 +465,11 @@ public class BluetoothChatService implements Serializable{
                 // This is a blocking call and will only return on a
                 // successful connection or an exception
                 mmSocket.connect();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 // Close the socket
                 try {
                     mmSocket.close();
-                } catch (IOException e2) {
+                } catch (Exception e2) {
                     Log.e(TAG, "unable to close() " + mSocketType +
                             " socket during connection failure", e2);
                 }


### PR DESCRIPTION
# Fixes #818 
- Catch all exceptions with the socket (if it is null, it will fail the connection, but no crash)