### PR TITLE
network: new open wifi matcher (#836)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/utils/CommandManager.kt
+++ b/app/src/main/java/io/treehouses/remote/utils/CommandManager.kt
@@ -81,7 +81,7 @@ object Matcher {
 
     fun isHotspotConnected (output: String): Boolean {return toLC(output).contains("pirateship has anchored successfully")}
 
-    fun isWifiConnected (output: String): Boolean {return output.contains("open wifi network") || output.contains("password network")}
+    fun isWifiConnected (output: String): Boolean {return output.contains("open network") || output.contains("password network")}
 
     fun isDefaultNetwork(output: String): Boolean {return toLC(output).contains("the network mode has been reset to default")}
 


### PR DESCRIPTION
# Fixes #836 

## Fix
`open network` not `open wifi network`
## Reference
https://github.com/treehouses/cli/blob/167109d54ddb6d433b226d4a686b1b0ce05f4e37/modules/wifi.sh#L61