### PR TITLE
fdroid: literal values of versionCode and versionName

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-def appVersionCode = Integer.valueOf(System.env.TRAVIS_BUILD_NUMBER ?: 2)
-def appVersionName = (System.env.TRAVIS_BUILD_NUMBER ?: "1.0.0")
 
 android {
     compileSdkVersion 29
@@ -12,8 +10,8 @@ android {
         minSdkVersion 15
         targetSdkVersion 29
         multiDexEnabled true
-        versionCode appVersionCode
-        versionName appVersionName + ""
+        versionCode Integer.valueOf(System.env.TRAVIS_BUILD_NUMBER ?: 2)
+        versionName (System.env.TRAVIS_BUILD_NUMBER ?: "1.0.0") + ""
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         applicationVariants.all { variant ->
             variant.outputs.all { output ->


### PR DESCRIPTION
In accordance with [F-Droid](https://gitlab.com/fdroid/rfp/-/issues/1384)'s update tracker:
> uses variables for versionCode and versionName – our update checker would need literal/static values here

