### PR TITLE
terminal: no crash (fixes #880)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.kt
+++ b/app/src/main/java/io/treehouses/remote/adapter/CommandListAdapter.kt
@@ -22,7 +22,7 @@ class CommandListAdapter(private val context: Context, private val expandableLis
         return expandedListPosition.toLong()
     }
 
-    override fun getChildView(listPosition: Int, expandedListPosition: Int, isLastChild: Boolean, convertView: View, parent: ViewGroup): View {
+    override fun getChildView(listPosition: Int, expandedListPosition: Int, isLastChild: Boolean, convertView: View?, parent: ViewGroup): View {
         var convertView = convertView
         val expandedListText = getChild(listPosition, expandedListPosition) as String
         if (expandedListPosition == expandableListDetail[expandableListTitle[listPosition]]!!.size) {
@@ -54,7 +54,7 @@ class CommandListAdapter(private val context: Context, private val expandableLis
     }
 
     override fun getGroupView(listPosition: Int, isExpanded: Boolean,
-                              convertView: View, parent: ViewGroup): View {
+                              convertView: View?, parent: ViewGroup): View {
         var convertView = convertView
         val listTitle = getGroup(listPosition) as String
         if (convertView == null) {


### PR DESCRIPTION
# Fixes #880 

## Issue
- During kotlinification, convertview was made from a nullable type to a non-nullable type

## Fix
- convertView can be null, so make it a nullable type