### PR TITLE
system: no white text (fixes #911)

### DIFF
--- a/app/src/main/res/layout/configure_ssh_key.xml
+++ b/app/src/main/res/layout/configure_ssh_key.xml
@@ -16,6 +16,7 @@
             android:id="@+id/editTextSSHKey"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textColor="@color/daynight_textColor"
             android:hint="SSH Key" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/configure_tethering.xml
+++ b/app/src/main/res/layout/configure_tethering.xml
@@ -16,6 +16,7 @@
             android:id="@+id/editTextSSID"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textColor="@color/daynight_textColor"
             android:hint="Hotspot SSID" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -32,7 +33,7 @@
             android:id="@+id/editTextPassword"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-
+            android:textColor="@color/daynight_textColor"
             android:hint="@string/password"
             android:inputType="textPassword" />
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/configure_wificountry.xml
+++ b/app/src/main/res/layout/configure_wificountry.xml
@@ -21,6 +21,7 @@
             android:focusable="false"
             android:clickable="true"
             android:drawableRight="@drawable/keyboard_arrow_down_24px"
+            android:textColor="@color/daynight_textColor"
             android:gravity="center"
             android:text="Getting Country from Pi"
             android:hint="" />

--- a/app/src/main/res/layout/open_vnc.xml
+++ b/app/src/main/res/layout/open_vnc.xml
@@ -13,6 +13,7 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editTextIp"
+            android:textColor="@color/daynight_textColor"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 


### PR DESCRIPTION
fixes #911 

### Testing:

Go to **System Fragment** and type in text on all the edit texts and color should be correct in dark mode **ON** as well as **OFF**