### PR TITLE
settings: reactivate tutorials (fixes #977)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
@@ -2,6 +2,7 @@ package io.treehouses.remote.Fragments
 
 import android.app.AlertDialog
 import android.content.DialogInterface
+import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.os.Bundle
 import android.util.Log
@@ -21,11 +22,12 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
         val clearCommandsList = findPreference<Preference>("clear_commands")
         val resetCommandsList = findPreference<Preference>("reset_commands")
         val clearNetworkProfiles = findPreference<Preference>("network_profiles")
-
+        val reactivateTutorials = findPreference<Preference>("reactivate_tutorials")
 
         setClickListener(clearCommandsList)
         setClickListener(resetCommandsList)
         setClickListener(clearNetworkProfiles)
+        setClickListener(reactivateTutorials)
 
         preferenceChangeListener = OnSharedPreferenceChangeListener { sharedPreferences, key ->
             if (key == "dark_mode") {
@@ -67,6 +69,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
             "clear_commands" -> clearCommands()
             "reset_commands" -> resetCommands()
             "network_profiles" -> networkProfiles()
+            "reactivate_tutorials" -> reactivateTutorialsPrompt()
         }
         return false
     }
@@ -110,12 +113,30 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
                 Toast.makeText(context, "Commands has been reset to default", Toast.LENGTH_LONG).show()
             }
             NETWORK_PROFILES_ID -> clearNetworkProfiles()
+            REACTIVATE_TUTORIALS -> reactivateTutorials()
         }
+    }
+
+    private fun reactivateTutorialsPrompt() {
+        createAlertDialog("Reactivate Tutorials", "Would you like to reactivate all the tutorials in the application? ", "Reactivate", REACTIVATE_TUTORIALS)
+    }
+
+    private fun reactivateTutorials() {
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.HOME, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.NETWORK, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SERVICES_DETAILS, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SERVICES_OVERVIEW, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.STATUS, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SYSTEM, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.TERMINAL, true)
+        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.TUNNEL, true)
+        Toast.makeText(context, "Tutorials reactivated", Toast.LENGTH_LONG).show()
     }
 
     companion object {
         private const val CLEAR_COMMANDS_ID = 1
         private const val RESET_COMMANDS_ID = 2
         private const val NETWORK_PROFILES_ID = 3
+        private const val REACTIVATE_TUTORIALS = 4
     }
 }

--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
@@ -2,7 +2,6 @@ package io.treehouses.remote.Fragments
 
 import android.app.AlertDialog
 import android.content.DialogInterface
-import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.os.Bundle
 import android.util.Log

--- a/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/SettingsFragment.kt
@@ -121,14 +121,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
     }
 
     private fun reactivateTutorials() {
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.HOME, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.NETWORK, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SERVICES_DETAILS, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SERVICES_OVERVIEW, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.STATUS, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.SYSTEM, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.TERMINAL, true)
-        SaveUtils.setFragmentFirstTime(requireContext(), SaveUtils.Screens.TUNNEL, true)
+        for(screen in SaveUtils.Screens.values()) SaveUtils.setFragmentFirstTime(requireContext(), screen, true)
         Toast.makeText(context, "Tutorials reactivated", Toast.LENGTH_LONG).show()
     }
 

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -75,7 +75,10 @@
             <intent android:action="android.intent.action.VIEW"
                 android:data="https://github.com/treehouses/remote/issues"/>
         </Preference>
-
+        <Preference
+            android:title="Reactivate Tutorials"
+            android:key="reactivate_tutorials">
+        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Advanced">


### PR DESCRIPTION
Instead of having to reinstall every time, a setting to **reactivate tutorials** has been **added** for ease of use

For testing:
Check if tutorials are showing up after reactivated