### PR TITLE
home: get started (fixes #1039)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/HomeFragment.kt
@@ -62,7 +62,8 @@ class HomeFragment : BaseHomeFragment(), SetDisconnect {
                 instance!!.openCallFragment(TerminalFragment())
                 activity?.let { it.title = "Terminal" }
             } else {
-                Toast.makeText(context,"Please connect to the Raspberry Pi", Toast.LENGTH_SHORT).show()
+                instance!!.openCallFragment(AboutFragment())
+                activity?.let { it.title = "About" }
             }
         }
         testConnectionListener()


### PR DESCRIPTION
Fixes #1039 

### How to test

When the raspberry pi is not connected, click "Get Started" on the home page and it should direct you to the about page instead of saying "Please connect to the raspberry pi"
![Screenshot_20200703-212114_Treehouses Remote](https://user-images.githubusercontent.com/44847682/86504922-8183ab00-bd73-11ea-832d-99b9e30a28fd.jpg)