### PR TITLE
tunnel: remove empty tor port (fixes #1024)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -63,7 +63,6 @@ class TorTabFragment : BaseFragment() {
         portList!!.onItemClickListener = OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->
             val builder = AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle))
             builder.setTitle("Delete Port " + portsName!![position] + " ?")
-
 //            builder.setMessage("Would you like to delete?");
 
             // add the buttons
@@ -187,6 +186,9 @@ class TorTabFragment : BaseFragment() {
                     addPortButton!!.isEnabled = true
                     val ports = readMessage.split(" ".toRegex()).toTypedArray()
                     for (i in ports.indices) {
+                        if(i == ports.size - 1){
+                            break
+                        }
                         portsName!!.add(ports[i])
                     }
                     adapter = ArrayAdapter(requireContext(), android.R.layout.select_dialog_item, portsName!!)


### PR DESCRIPTION
Fixes #1024

`readMessage.split(" ".toRegex())` was taking the last space from the output of  `treehouses tor ports`, so breaking at the last loop iteration fixes this.

![image](https://user-images.githubusercontent.com/35390215/86631781-8b3c2700-bf9c-11ea-8be9-242a9261c24b.png)
