### PR TITLE
services: loading background dark compatible (fixes #1065)

### DIFF
--- a/app/src/main/res/layout/activity_services_fragment.xml
+++ b/app/src/main/res/layout/activity_services_fragment.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/md_grey_300">
+    android:background="@color/services_tab_background">
 
     <ProgressBar
         android:id="@+id/progressBar2"


### PR DESCRIPTION
fixes #1065
<img width = "400" src = https://user-images.githubusercontent.com/20432955/86989768-23870700-c169-11ea-8877-fc02538db791.jpg>
