### PR TITLE
services: cached loading (fixes #1076)

### DIFF
--- a/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
@@ -29,8 +29,7 @@ class ServicesFragment : BaseServicesFragment(), ServicesListener {
     private var servicesTabFragment: ServicesTabFragment? = null
     private var servicesDetailsFragment: ServicesDetailsFragment? = null
     var bind: ActivityServicesFragmentBinding? = null
-    var counter = 0
-
+    private var counter = 0
     override fun onSaveInstanceState(outState: Bundle) {
 
     }
@@ -64,6 +63,7 @@ class ServicesFragment : BaseServicesFragment(), ServicesListener {
             val a = performAction(output!!, services)
             if (a == 1) {
                 showUI()
+                writeToRPI("treehouses remote allservices\n")
                 worked = true
             }
         }

--- a/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
@@ -75,9 +75,6 @@ class ServicesFragment : BaseServicesFragment(), ServicesListener {
                     servicesDetailsFragment?.arguments = bundle
                     bind!!.progressBar2.visibility = View.GONE
                     replaceFragment(0)
-                } else if (a == 0) {
-                    bind!!.progressBar2.visibility = View.GONE
-                    showUpdateCliAlert()
                 }
             }
        }

--- a/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/ServicesFragment.kt
@@ -7,14 +7,12 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.os.Handler
 import android.os.Message
-import android.util.Base64.encodeToString
 import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
@@ -92,31 +90,33 @@ class ServicesFragment : BaseServicesFragment(), ServicesListener {
                 Constants.MESSAGE_READ -> {
                     val sharedPreferences: SharedPreferences = requireContext().getSharedPreferences("ServicesPref", MODE_PRIVATE)
                     val output:String? = msg.obj as String
-                    val a = performAction(output!!, services)
-                    if (a == 1) {
-                        counter += 1
-                        val myEdit = sharedPreferences.edit()
-                        myEdit.putString("output$counter", output)
-                        myEdit.putBoolean("flag", true)
-                        myEdit.putInt("max", counter)
-                        myEdit.apply()
-                        servicesTabFragment = ServicesTabFragment()
-                        servicesDetailsFragment = ServicesDetailsFragment()
-                        val bundle = Bundle()
-                        bundle.putSerializable("services", services)
-                        servicesTabFragment?.arguments = bundle
-                        servicesDetailsFragment?.arguments = bundle
-                        bind!!.progressBar2.visibility = View.GONE
-                        replaceFragment(0)
-                    } else if (a == 0) {
-                        bind!!.progressBar2.visibility = View.GONE
-                        showUpdateCliAlert()
-                    }
-                    else {
-                        counter += 1
-                        val myEdit = sharedPreferences.edit()
-                        myEdit.putString("output$counter", output)
-                        myEdit.apply()
+                    when (performAction(output!!, services)) {
+                        1 -> {
+                            counter += 1
+                            val myEdit = sharedPreferences.edit()
+                            myEdit.putString("output$counter", output)
+                            myEdit.putBoolean("flag", true)
+                            myEdit.putInt("max", counter)
+                            myEdit.apply()
+                            servicesTabFragment = ServicesTabFragment()
+                            servicesDetailsFragment = ServicesDetailsFragment()
+                            val bundle = Bundle()
+                            bundle.putSerializable("services", services)
+                            servicesTabFragment?.arguments = bundle
+                            servicesDetailsFragment?.arguments = bundle
+                            bind!!.progressBar2.visibility = View.GONE
+                            replaceFragment(0)
+                        }
+                        0 -> {
+                            bind!!.progressBar2.visibility = View.GONE
+                            showUpdateCliAlert()
+                        }
+                        else -> {
+                            counter += 1
+                            val myEdit = sharedPreferences.edit()
+                            myEdit.putString("output$counter", output)
+                            myEdit.apply()
+                        }
                     }
                 }
                 Constants.MESSAGE_WRITE -> {


### PR DESCRIPTION
fixes #1076

**Working:**
The first visit to services will take the usual loading time but then the list will be saved in local phone memory to instantly show the next time user comes to services without having to wait for loading but the loading would still be happening in the background and once done it will update the list.

**Testing:**
There should not be any glitches especially memory progress bar not displaying etc