### PR TITLE
terminal: selectable command description in help (fixes #1089)

### DIFF
--- a/app/src/main/res/layout/dialog_help.xml
+++ b/app/src/main/res/layout/dialog_help.xml
@@ -64,6 +64,7 @@
                     android:padding="@dimen/padding_normal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:textIsSelectable="true"
                     android:textColor = "@color/expandable_child_text"
                     tools:text="@tools:sample/lorem/random"/>
             </ScrollView>


### PR DESCRIPTION
# Fixes #1089 

Can select text in help menu