### PR TITLE
ssh: improved dialog (fixes #1093)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         //Uncomment for debugging
-        debug {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+//        debug {
+//            minifyEnabled true
+//            shrinkResources true
+//            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+//        }
 
     }
     lintOptions {

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/FeedbackDialogFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/FeedbackDialogFragment.kt
@@ -12,12 +12,13 @@ import android.widget.Toast
 import android.util.Patterns
 import androidx.fragment.app.DialogFragment
 import io.treehouses.remote.Network.ParseDbService
+import io.treehouses.remote.bases.FullScreenDialogFragment
 import io.treehouses.remote.databinding.DialogFeedbackBinding
 import io.treehouses.remote.utils.Utils
 import java.util.HashMap
 
 
-class FeedbackDialogFragment : DialogFragment() {
+class FeedbackDialogFragment : FullScreenDialogFragment() {
     private lateinit var bind: DialogFeedbackBinding
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -71,19 +72,5 @@ class FeedbackDialogFragment : DialogFragment() {
                 bind.editEmail.text.toString().isNotBlank() &&
                 bind.editMessage.text.toString().isNotBlank() &&
                 (bind.radioButtonBug.isChecked || bind.radioButtonSuggestion.isChecked)
-    }
-
-
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        return dialog
-
-    }
-
-    override fun onStart() {
-        super.onStart()
-        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
 }

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/HelpDialog.kt
@@ -6,17 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.treehouses.remote.Constants
 import io.treehouses.remote.Views.RecyclerViewClickListener
 import io.treehouses.remote.adapter.HelpAdapter
+import io.treehouses.remote.bases.FullScreenDialogFragment
 import io.treehouses.remote.databinding.DialogHelpBinding
 import io.treehouses.remote.pojo.HelpCommand
 import org.json.JSONObject
 
 
-class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListener {
+class HelpDialog : FullScreenDialogFragment(), android.widget.SearchView.OnQueryTextListener {
     private lateinit var bind: DialogHelpBinding
     private var jsonString = ""
     private val items = mutableListOf<HelpCommand>()
@@ -74,18 +74,6 @@ class HelpDialog : DialogFragment(), android.widget.SearchView.OnQueryTextListen
         bind.showHelp.visibility = View.VISIBLE
         bind.titleDescription.text = item.title
         bind.description.text = item.preview
-    }
-
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        return dialog
-    }
-
-    override fun onStart() {
-        super.onStart()
-        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
 
     private fun createJson(jsonStr: String) {

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/SSHDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/SSHDialog.kt
@@ -1,29 +1,47 @@
 package io.treehouses.remote.Fragments.DialogFragments
 
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Intent
+import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import androidx.appcompat.app.AppCompatActivity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.fragment.app.FragmentActivity
 import io.treehouses.remote.Fragments.SSHConsole
-import io.treehouses.remote.R
 import io.treehouses.remote.SSH.beans.HostBean
+import io.treehouses.remote.bases.BaseDialogFragment
 import io.treehouses.remote.databinding.DialogSshBinding
 import java.util.regex.Pattern
 
-class SSHDialog(activity: AppCompatActivity) {
+
+class SSHDialog : BaseDialogFragment() {
     private val sshPattern = Pattern.compile("^(.+)@(([0-9a-z.-]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE)
-    private var bind: DialogSshBinding = DialogSshBinding.inflate(activity.layoutInflater)
-    private var dialog: AlertDialog? = null
-    init {
+    private lateinit var bind: DialogSshBinding
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        bind = DialogSshBinding.inflate(inflater, container, false)
+        return bind.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setEnabled(false)
         addTextValidation()
         bind.connectSsh.setOnClickListener {
-            launchSSH(activity, bind.sshTextInput.text.toString().split("@")[0], bind.sshTextInput.text.toString().split("@")[1])
-            dialog?.dismiss()
+            launchSSH(requireActivity(), bind.sshTextInput.text.toString().split("@")[0], bind.sshTextInput.text.toString().split("@")[1])
         }
-        dialog = AlertDialog.Builder(activity).setTitle("Start SSH Connection").setView(bind.root).setIcon(R.drawable.dialog_icon).create()
-        dialog?.show()
     }
 
     private fun addTextValidation() {
@@ -49,7 +67,7 @@ class SSHDialog(activity: AppCompatActivity) {
         bind.connectSsh.isClickable = bool
     }
 
-    private fun launchSSH(activity: AppCompatActivity, username: String, hostname: String) {
+    private fun launchSSH(activity: FragmentActivity, username: String, hostname: String) {
         val host = HostBean()
         host.username = username
         host.hostname = hostname
@@ -57,5 +75,6 @@ class SSHDialog(activity: AppCompatActivity) {
         contents.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         contents.setClass(activity, SSHConsole::class.java)
         activity.startActivity(contents)
+        dialog?.dismiss()
     }
 }

--- a/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/SSHDialog.kt
+++ b/app/src/main/java/io/treehouses/remote/Fragments/DialogFragments/SSHDialog.kt
@@ -1,7 +1,5 @@
 package io.treehouses.remote.Fragments.DialogFragments
 
-import android.app.AlertDialog
-import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
@@ -9,27 +7,17 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
 import androidx.fragment.app.FragmentActivity
 import io.treehouses.remote.Fragments.SSHConsole
 import io.treehouses.remote.SSH.beans.HostBean
-import io.treehouses.remote.bases.BaseDialogFragment
+import io.treehouses.remote.bases.FullScreenDialogFragment
 import io.treehouses.remote.databinding.DialogSshBinding
 import java.util.regex.Pattern
 
 
-class SSHDialog : BaseDialogFragment() {
+class SSHDialog : FullScreenDialogFragment() {
     private val sshPattern = Pattern.compile("^(.+)@(([0-9a-z.-]+)|(\\[[a-f:0-9]+\\]))(:(\\d+))?$", Pattern.CASE_INSENSITIVE)
     private lateinit var bind: DialogSshBinding
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
-        return dialog
-    }
-
-    override fun onStart() {
-        super.onStart()
-        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-    }
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = DialogSshBinding.inflate(inflater, container, false)
         return bind.root

--- a/app/src/main/java/io/treehouses/remote/InitialActivity.kt
+++ b/app/src/main/java/io/treehouses/remote/InitialActivity.kt
@@ -94,7 +94,7 @@ class InitialActivity : PermissionActivity(), NavigationView.OnNavigationItemSel
             when (id) {
                 R.id.menu_about -> openCallFragment(AboutFragment())
                 R.id.menu_home -> openCallFragment(HomeFragment())
-                R.id.menu_ssh -> SSHDialog(this)
+                R.id.menu_ssh -> SSHDialog().show(supportFragmentManager, "SSH")
             }
         }
         title = item.title
@@ -118,7 +118,7 @@ class InitialActivity : PermissionActivity(), NavigationView.OnNavigationItemSel
             R.id.menu_about -> openCallFragment(AboutFragment())
             R.id.menu_status -> openCallFragment(StatusFragment())
             R.id.menu_tunnel2 -> openCallFragment(SSHTunnelFragment())
-            R.id.menu_ssh -> SSHDialog(this)
+            R.id.menu_ssh -> SSHDialog().show(supportFragmentManager, "SSH")
             else -> openCallFragment(HomeFragment())
 
         }

--- a/app/src/main/java/io/treehouses/remote/bases/FullScreenDialogFragment.kt
+++ b/app/src/main/java/io/treehouses/remote/bases/FullScreenDialogFragment.kt
@@ -1,0 +1,17 @@
+package io.treehouses.remote.bases
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.ViewGroup
+
+open class FullScreenDialogFragment : BaseDialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+}

--- a/app/src/main/res/drawable/rectangle_border.xml
+++ b/app/src/main/res/drawable/rectangle_border.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <stroke android:width="0.35dp" android:color="@color/md_grey_800"/>
+    <stroke android:width="0.35dp" android:color="@color/rectangle_border_color"/>
     <corners android:radius="4dp"/>
 </shape>

--- a/app/src/main/res/layout/dialog_ssh.xml
+++ b/app/src/main/res/layout/dialog_ssh.xml
@@ -3,15 +3,26 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:background="@color/card_background"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Start SSH Connection"
+        android:textColor="@color/daynight_textColor"
+        android:paddingStart="@dimen/padding_normal"
+        android:paddingEnd="@dimen/padding_normal"
+        android:paddingTop="@dimen/padding_normal"
+        android:gravity="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title"/>
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/ssh_text_input"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:background="@drawable/rectangle_border"
         android:padding="@dimen/padding_normal"
         android:layout_margin="@dimen/margin_large"
+        android:textColorHint="@color/md_grey_500"
         android:hint="pi@192.168.1.29"
         />
 

--- a/app/src/main/res/values-night/color.xml
+++ b/app/src/main/res/values-night/color.xml
@@ -24,6 +24,8 @@
     <color name="terminal">#FFFFFF</color>
     <color name="back_arrow">#CCCCCC</color>
 
+    <color name="rectangle_border_color">@color/md_grey_500</color>
+
     <color name="black_overlay">#66000000</color>
     <color name="bg_white">#ffffff</color>
     <color name="red">#66ff0000</color>

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -24,6 +24,8 @@
     <color name="terminal">@color/md_blue_A700</color>
     <color name="back_arrow">#585858</color>
 
+    <color name="rectangle_border_color">@color/md_grey_800</color>
+
     <color name="black_overlay">#66000000</color>
     <color name="bg_white">#ffffff</color>
     <color name="red">#66ff0000</color>


### PR DESCRIPTION
# Fixes #1093 
- Changed to dialog fragment
- changed to dark mode
<img width="440" alt="Screen Shot 2020-07-13 at 4 24 08 PM" src="https://user-images.githubusercontent.com/37857112/87350444-df5b8400-c525-11ea-9bc4-4947a8bbe7e1.png">

To resolve some CodeClimate Issues, a common FullScreenDialogFragment was created. However, it uses `WRAP_CONTENT` instead of `MATCH_PARENT` to let the layout file determine the height of the layout. So please also test:

- HelpDialog in Terminal
- FeedbackDialog

