### PR TITLE
home: always unregister RPIDialog Receiver (fixes #1121)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/RPIDialogFragment.kt
@@ -145,7 +145,7 @@ class RPIDialogFragment : BaseDialogFragment() {
     override fun onDestroy() {
         super.onDestroy()
         try {
-            if (mBluetoothAdapter == null) requireContext().unregisterReceiver(mReceiver)
+            requireContext().unregisterReceiver(mReceiver)
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
# fixes #1121 

- Always unregister the RPIDialog Receiver