### PR TITLE
ssh: dark mode dialog (fixes #1130)

### DIFF
--- a/app/src/main/res/layout/dialog_ssh.xml
+++ b/app/src/main/res/layout/dialog_ssh.xml
@@ -24,7 +24,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_large"
         android:background="@drawable/rectangle_border"
-        android:hint="pi@192.168.1.29"
+        android:hint="user@hostname:port"
         android:padding="@dimen/padding_normal"
         android:textColorHint="@color/md_grey_500" />
 

--- a/app/src/main/res/layout/dialog_ssh.xml
+++ b/app/src/main/res/layout/dialog_ssh.xml
@@ -61,7 +61,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/md_grey_500"
+            android:textColor="@color/grey_to_light_grey"
             android:textSize="@dimen/text_size_mid"
             android:layout_marginTop="@dimen/margin_medium"
             android:text="There are no saved hosts!"/>

--- a/app/src/main/res/layout/row_ssh.xml
+++ b/app/src/main/res/layout/row_ssh.xml
@@ -10,12 +10,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textSize="@dimen/text_size_mid"
+        android:textColor="@color/grey_to_light_grey"
         android:padding="@dimen/padding_large"
         tools:text="pi@192.168.1.29" />
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="@color/md_grey_200"/>
+        android:background="@color/divider_colour"/>
 
 </LinearLayout>

--- a/app/src/main/res/values-night/color.xml
+++ b/app/src/main/res/values-night/color.xml
@@ -30,6 +30,8 @@
     <color name="black_overlay">#66000000</color>
     <color name="bg_white">#ffffff</color>
     <color name="red">#66ff0000</color>
+    <color name="divider_colour">@color/md_grey_700</color>
+    <color name="grey_to_light_grey">@color/md_grey_300</color>
 
     <color name="dialog_sync_labels">#000000</color>
 

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -39,6 +39,9 @@
     <color name="material_drawer_unavailable_text">#71AADA</color>
     <color name="offwhite">#fafafa</color>
 
+    <color name="divider_colour">@color/md_grey_300</color>
+    <color name="grey_to_light_grey">@color/md_grey_600</color>
+
     <!-- changes logout button area background from white to whatever the background color for the drawer is.
     Without it, the drawer and logout button area are different colors -->
     <color name="material_drawer_background">@color/colorPrimary</color>


### PR DESCRIPTION
# fixes #1130 
<img width="437" alt="Screen Shot 2020-07-17 at 7 57 32 PM" src="https://user-images.githubusercontent.com/37857112/87839192-c1fd2180-c867-11ea-95fd-0ad2d6ee0632.png">

- Updated the hint
- Added new colours for dark mode