### PR TITLE
status: refresh (fixes #1153) (fixes #1154) (fixes #1155)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -44,8 +44,14 @@ class StatusFragment : BaseFragment() {
         mChatService.updateHandler(mHandler)
         deviceName = mChatService.connectedDeviceName
         checkStatusNow()
-        writeToRPI("treehouses remote status")
+        refresh()
+        bind.refreshBtn.setOnClickListener { refresh() }
         return bind.root
+    }
+
+    private fun refresh() {
+        writeToRPI("treehouses remote status")
+        bind.refreshBtn.visibility = View.GONE
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -68,7 +74,7 @@ class StatusFragment : BaseFragment() {
     }
 
     private fun rpiNameOnViewClickListener() {
-        bind.editName.setOnClickListener { showRenameDialog() }
+        bind.editName.setOnClickListener {showRenameDialog()}
     }
 
     private fun updateStatus(readMessage: String) {
@@ -109,6 +115,7 @@ class StatusFragment : BaseFragment() {
             writeToRPI("treehouses internet")
         } else if (lastCommand == "treehouses internet") {
             checkWifiStatus(readMessage)
+            bind.refreshBtn.visibility = View.VISIBLE
         } else {
             checkUpgradeStatus(readMessage)
         }
@@ -152,7 +159,7 @@ class StatusFragment : BaseFragment() {
             bind.progressBar.visibility = View.GONE
             Toast.makeText(context, "Treehouses Cli has been updated!!!", Toast.LENGTH_LONG).show()
             notificationListener!!.setNotification(false)
-            requireActivity().supportFragmentManager.beginTransaction().replace(R.id.fragment_container, StatusFragment()).commit()
+            refresh()
         }
     }
 
@@ -186,6 +193,7 @@ class StatusFragment : BaseFragment() {
                     if (mEditText.text.toString() != "") {
                         writeToRPI("treehouses rename " + mEditText.text.toString())
                         Toast.makeText(context, "Raspberry Pi Renamed", Toast.LENGTH_LONG).show()
+                        refresh()
                     } else {
                         Toast.makeText(context, "Please enter a new name", Toast.LENGTH_LONG).show()
                     }

--- a/app/src/main/res/layout/activity_status_fragment.xml
+++ b/app/src/main/res/layout/activity_status_fragment.xml
@@ -33,6 +33,21 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <Button
+            android:id="@+id/refreshBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="25dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginBottom="4dp"
+            android:background="@drawable/bluetooth_btn"
+            android:text="Refresh"
+            android:textColor="@color/bg_white"
+            app:layout_constraintBottom_toTopOf="@id/bluetoothBox"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <LinearLayout
             android:id="@+id/bluetoothBox"
 
@@ -374,6 +389,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="10dp"
                         android:layout_marginRight="10dp"
+                        android:background="@drawable/ic_connect_to_rpi"
                         android:text="Upgrade?"
                         android:theme="@style/PrimaryButton"
                         android:visibility="visible"


### PR DESCRIPTION
fixes #1153
fixes #1154 
fixes #1155

### UI Changes:
1. Added Refresh Button
2. Rounded Corners of Upgrade Button

### Functionality Changes:
1. Manage the process of checking everything via refresh function.
2. Refresh Button can call the refresh function to recheck data anytime.
3. After the CLI upgrade refresh is now called instead of recreating fragment.
4. Hostname rename also results in a refresh function call resulting in rename result shown immediately instead of the next visit.

### Testing:
1. Use Refresh Button to Recheck data, maybe change the CLI version on Pi while staying on the status page, and see if refreshing reflects the change.
2. Refresh Button should disappear once used and only come back when the refresh is complete.
3. Rename Hostname and the change should reflect on the status page without having to use the refresh button, it should trigger refresh itself.

### Screenshots of Changed UI:
<img width = "400" src = https://user-images.githubusercontent.com/20432955/87991673-aa66a880-cab4-11ea-8d0c-4ff770b03783.jpg>
<img width = "400" src = https://user-images.githubusercontent.com/20432955/87991674-aa66a880-cab4-11ea-9d97-e7289666c8b9.jpg>
