### PR TITLE
tutorials: allow skipping (fixes #1157)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/IntroActivity.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/IntroActivity.kt
@@ -16,6 +16,7 @@ import io.treehouses.remote.databinding.ActivityIntroBinding
 import io.treehouses.remote.databinding.IntroScreenBluetoothBinding
 import io.treehouses.remote.databinding.IntroScreenDownloadBinding
 import io.treehouses.remote.databinding.IntroScreenWelcomeBinding
+import io.treehouses.remote.utils.SaveUtils
 
 class IntroActivity : AppCompatActivity() {
     lateinit var binding: ActivityIntroBinding
@@ -62,6 +63,10 @@ class IntroActivity : AppCompatActivity() {
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             super.onViewCreated(view, savedInstanceState)
             bind.nextBtn.setOnClickListener { listener.goToPosition(1) }
+            bind.skipBtn.setOnClickListener {
+                for(screen in SaveUtils.Screens.values()) SaveUtils.setFragmentFirstTime(requireContext(), screen, false)
+                listener.goToMain()
+            }
         }
     }
 

--- a/app/src/main/res/layout/intro_screen_welcome.xml
+++ b/app/src/main/res/layout/intro_screen_welcome.xml
@@ -64,4 +64,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messageTutorial"
         app:layout_constraintWidth_percent="0.3" />
+
+    <Button
+        android:id="@+id/skipBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_large"
+        android:background="@drawable/service_button"
+        android:text="Skip Tutorials"
+        android:textAllCaps="false"
+        android:textColor="@color/bg_white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/nextBtn"
+        app:layout_constraintWidth_percent="0.3" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
fixes #1157

### UI Changes:
Added Skip Tutorials Button

### Functionality Changes:
Using Skip Tutorials Button disables all the tutorials throughout the app unless Reactivated from Settings or App Data Cleared.

### Screenshot of UI Change:
<img width = "400" src = https://user-images.githubusercontent.com/20432955/87993705-2d89fd80-cab9-11ea-9e2f-fd59c1b5a58d.jpg>
