### PR TITLE
ssh: terminal spacing (fixes #1171)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/SSH/Terminal/TerminalBridge.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/SSH/Terminal/TerminalBridge.kt
@@ -499,7 +499,7 @@ class TerminalBridge : VDUDisplay {
         if (width <= 0 || height <= 0) return
         val clipboard = parent.context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         keyHandler.setClipboardManager(clipboard)
-        if (!forcedSize) checkDimensions(width, height)
+        if (!forcedSize && checkDimensions(width, height)) return
 
         checkBitMap(width, height)
 
@@ -528,7 +528,7 @@ class TerminalBridge : VDUDisplay {
         }
     }
 
-    fun checkDimensions(width: Int, height: Int) {
+    fun checkDimensions(width: Int, height: Int) : Boolean {
         // recalculate buffer size
         val newColumns: Int
         val newRows: Int
@@ -537,10 +537,11 @@ class TerminalBridge : VDUDisplay {
 
         // If nothing has changed in the terminal dimensions and not an intial
         // draw then don't blow away scroll regions and such.
-        if (newColumns == columns && newRows == rows) return
+        if (newColumns == columns && newRows == rows) return true
         columns = newColumns
         rows = newRows
         refreshOverlayFontSize()
+        return false
     }
 
     fun redrawLocal() {


### PR DESCRIPTION
# Fixes #1171 
The spacing on ssh terminal is now fixed. 
<img width="441" alt="Screen Shot 2020-07-22 at 9 08 50 PM" src="https://user-images.githubusercontent.com/37857112/88243778-8b584a00-cc5f-11ea-8a19-1a693e41e49a.png">
