### PR TITLE
ssh: delete ssh key functionality (fixes #1202)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/DeleteSSHKey.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/DeleteSSHKey.kt
@@ -1,0 +1,59 @@
+package io.treehouses.remote.Fragments.DialogFragments
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import io.treehouses.remote.bases.FullScreenDialogFragment
+import io.treehouses.remote.databinding.DialogDeleteSshKeyBinding
+import io.treehouses.remote.utils.KeyUtils
+
+class DeleteSSHKey : FullScreenDialogFragment() {
+    companion object {
+        const val KEY_TO_DELETE = "KEY_TO_DELETE"
+    }
+    private lateinit var bind : DialogDeleteSshKeyBinding
+    private lateinit var keyToDelete : String
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        bind = DialogDeleteSshKeyBinding.inflate(inflater, container, false)
+        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        keyToDelete = arguments?.getString(KEY_TO_DELETE)!!
+        return bind.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val titleText = "Delete $keyToDelete?"
+        bind.title.text = titleText
+
+        bind.deleteKeyConfirmation.hint = keyToDelete
+        bind.deleteKeyConfirmation.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) { setEnabled(s?.toString() == keyToDelete) }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        })
+
+        setEnabled(false)
+        bind.deleteButton.setOnClickListener {
+            if (bind.deleteKeyConfirmation.text.toString() == keyToDelete) {
+                KeyUtils.deleteKey(requireContext(), keyToDelete)
+                Toast.makeText(requireContext(), "Deleted $keyToDelete. Please Refresh Screen to see changes.", Toast.LENGTH_LONG).show()
+                dismiss()
+            }
+        }
+
+        bind.cancelButton.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun setEnabled(bool: Boolean) {
+        bind.deleteButton.isEnabled = bool
+        bind.deleteButton.isClickable = bool
+    }
+
+}

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/SSHAllKeys.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/SSHAllKeys.kt
@@ -57,8 +57,9 @@ class SSHAllKeys : FullScreenDialogFragment(), KeyMenuListener {
     private fun setUpAdapter() {
         bind.allKeys.adapter = object : RecyclerView.Adapter<ViewHolderSSHAllKeyRow>() {
             override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderSSHAllKeyRow {
-                val binding = RowKeyBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-                return ViewHolderSSHAllKeyRow(binding, this@SSHAllKeys)
+                return ViewHolderSSHAllKeyRow(
+                        RowKeyBinding.inflate(LayoutInflater.from(parent.context),
+                                parent, false), this@SSHAllKeys)
             }
 
             override fun getItemCount(): Int {

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/SSHAllKeys.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/DialogFragments/SSHAllKeys.kt
@@ -1,25 +1,30 @@
 package io.treehouses.remote.Fragments.DialogFragments
 
+import android.app.AlertDialog
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
+import io.treehouses.remote.R
 import io.treehouses.remote.SSH.PubKeyUtils
 import io.treehouses.remote.SSH.beans.PubKeyBean
 import io.treehouses.remote.adapter.ViewHolderSSHAllKeyRow
 import io.treehouses.remote.bases.FullScreenDialogFragment
-import io.treehouses.remote.callback.RVButtonClick
+import io.treehouses.remote.callback.KeyMenuListener
+import io.treehouses.remote.databinding.DialogDeleteSshKeyBinding
 import io.treehouses.remote.databinding.DialogViewKeysBinding
 import io.treehouses.remote.databinding.RowKeyBinding
 import io.treehouses.remote.utils.KeyUtils
 
 
-class SSHAllKeys : FullScreenDialogFragment() {
+class SSHAllKeys : FullScreenDialogFragment(), KeyMenuListener {
     private lateinit var bind : DialogViewKeysBinding
 
     private lateinit var allKeys: List<PubKeyBean>
@@ -32,6 +37,7 @@ class SSHAllKeys : FullScreenDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         bind.doneBtn.setOnClickListener { dismiss() }
+        registerForContextMenu(bind.allKeys);
         setUpKeys()
     }
 
@@ -52,11 +58,7 @@ class SSHAllKeys : FullScreenDialogFragment() {
         bind.allKeys.adapter = object : RecyclerView.Adapter<ViewHolderSSHAllKeyRow>() {
             override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderSSHAllKeyRow {
                 val binding = RowKeyBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-                return ViewHolderSSHAllKeyRow(binding, object : RVButtonClick {
-                    override fun onButtonClick(position: Int) {
-                        copyToClipboard(allKeys[position])
-                    }
-                })
+                return ViewHolderSSHAllKeyRow(binding, this@SSHAllKeys)
             }
 
             override fun getItemCount(): Int {
@@ -82,6 +84,19 @@ class SSHAllKeys : FullScreenDialogFragment() {
     companion object {
         const val SELECTED_HOST_URI = "SELECTEDHOST"
         const val NO_KEY = "No Key"
+    }
+
+    override fun onCopyPub(position: Int) {
+        copyToClipboard(allKeys[position])
+    }
+
+    override fun onDelete(position: Int) {
+        val dialog = DeleteSSHKey().apply {
+            arguments = Bundle().apply {
+                putString(DeleteSSHKey.KEY_TO_DELETE, allKeys[position].nickname)
+            }
+        }
+        dialog.show(parentFragmentManager, "Delete_key")
     }
 
 

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/ViewHolderSSHAllKeyRow.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/ViewHolderSSHAllKeyRow.kt
@@ -1,14 +1,47 @@
 package io.treehouses.remote.adapter
 
+import android.view.ContextMenu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.widget.PopupMenu
+import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
+import io.treehouses.remote.R
 import io.treehouses.remote.SSH.beans.PubKeyBean
-import io.treehouses.remote.callback.RVButtonClick
+import io.treehouses.remote.callback.KeyMenuListener
 import io.treehouses.remote.databinding.RowKeyBinding
 
-class ViewHolderSSHAllKeyRow(private val binding: RowKeyBinding, private val listener: RVButtonClick) : RecyclerView.ViewHolder(binding.root) {
+
+class ViewHolderSSHAllKeyRow(private val binding: RowKeyBinding, private val listener: KeyMenuListener) :
+        RecyclerView.ViewHolder(binding.root),
+        View.OnCreateContextMenuListener,
+        MenuItem.OnMenuItemClickListener,
+        PopupMenu.OnMenuItemClickListener {
+
     fun bind(host: PubKeyBean) {
-        binding.copyBtn.setOnClickListener { listener.onButtonClick(adapterPosition) }
+        itemView.setOnCreateContextMenuListener(this)
         binding.keyName.text = host.nickname
         binding.keyType.text = host.getDescription(itemView.context)
+        binding.actions.setOnClickListener {
+            val popup = PopupMenu(itemView.context, binding.actions)
+            popup.inflate(R.menu.keys_menu)
+            popup.setOnMenuItemClickListener(this)
+            popup.show()
+        }
+    }
+
+    override fun onCreateContextMenu(menu: ContextMenu?, v: View?, menuInfo: ContextMenu.ContextMenuInfo?) {
+        val menuInflater = MenuInflater(itemView.context)
+        menuInflater.inflate(R.menu.keys_menu, menu)
+        menu?.children?.forEach { it.setOnMenuItemClickListener(this) }
+    }
+
+    override fun onMenuItemClick(item: MenuItem?): Boolean {
+        when (item?.itemId) {
+            R.id.copy_public -> listener.onCopyPub(adapterPosition)
+            R.id.delete_key -> listener.onDelete(adapterPosition)
+        }
+        return false
     }
 }

--- a/app/src/main/kotlin/io/treehouses/remote/callback/KeyMenuListener.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/callback/KeyMenuListener.kt
@@ -1,0 +1,6 @@
+package io.treehouses.remote.callback
+
+interface KeyMenuListener {
+    fun onCopyPub(position: Int)
+    fun onDelete(position: Int)
+}

--- a/app/src/main/res/color/red_to_grey.xml
+++ b/app/src/main/res/color/red_to_grey.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorAccent" android:state_enabled="true"/>
+    <item android:color="@color/grey_to_light_grey" android:state_enabled="false"/>
+</selector>

--- a/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/grey_to_light_grey">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_delete_ssh_key.xml
+++ b/app/src/main/res/layout/dialog_delete_ssh_key.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/alertdialog_background"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="@dimen/padding_normal"
+        android:text="Delete SSH Key?"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title"
+        android:textColor="@color/daynight_textColor" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/grey_to_light_grey"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginLeft="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginRight="@dimen/margin_large"
+        android:padding="@dimen/padding_normal"
+        android:text="@string/delete_key_message" />
+
+    <EditText
+        android:id="@+id/delete_key_confirmation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_large"
+        android:textColor="@color/daynight_textColor"
+        android:textColorHint="@color/grey_to_light_grey"
+        android:background="@drawable/rectangle_border"
+        android:hint="NAMEOFKEY"
+        android:padding="@dimen/padding_normal" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/daynight_textColor"
+            android:layout_marginEnd="@dimen/margin_huge"
+            android:layout_marginRight="@dimen/margin_huge"
+            android:text="Cancel" />
+
+        <Button
+            android:id="@+id/deleteButton"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_huge"
+            android:layout_marginLeft="@dimen/margin_huge"
+            android:text="Delete"
+            android:textColor="@color/red_to_grey" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/row_key.xml
+++ b/app/src/main/res/layout/row_key.xml
@@ -34,10 +34,11 @@
     </LinearLayout>
 
     <Button
-        android:id="@+id/copy_btn"
+        android:id="@+id/actions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Copy Public"
+        android:background="@drawable/ic_baseline_more_vert_24"
+        style="@style/Widget.AppCompat.ActionButton"
         android:layout_margin="@dimen/margin_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/menu/keys_menu.xml
+++ b/app/src/main/res/menu/keys_menu.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/copy_public" android:title="Copy Public Key"/>
+    <item android:id="@+id/delete_key" android:title="Delete"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,5 +326,6 @@
 
     <string name="intro_slide_1_m1">Treehouses Remote requires a Raspberry Pi running a Treehouses Image in order to function properly.</string>
     <string name="intro_slide_welcome_m1">Treehouses Remote </string>
+    <string name="delete_key_message"><b>Warning</b>: This action is cannot be undone. To confirm, please type the name of the key in the space below:</string>
 
 </resources>


### PR DESCRIPTION
# Fixes #1202 
- Adds functionality to delete SSH Keys
- Does not allow user to delete key without confirmation
- Added context menu (on long click of recyclerview item) and popup menu on the button
<img width="440" alt="Screen Shot 2020-07-25 at 2 24 22 AM" src="https://user-images.githubusercontent.com/37857112/88450576-f5b6e900-ce1d-11ea-9e2c-bd37815806ea.png">
<img width="438" alt="Screen Shot 2020-07-25 at 2 24 59 AM" src="https://user-images.githubusercontent.com/37857112/88450589-0b2c1300-ce1e-11ea-8adc-dbfb60b6ab17.png">
<img width="439" alt="Screen Shot 2020-07-25 at 2 25 15 AM" src="https://user-images.githubusercontent.com/37857112/88450591-14b57b00-ce1e-11ea-8c1b-f5c719dc5a90.png">
