### PR TITLE
network: rounded bottomsheet dialogs (fixes #1258)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseBottomSheetDialog.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseBottomSheetDialog.kt
@@ -11,11 +11,6 @@ import io.treehouses.remote.callback.HomeInteractListener
 open class BaseBottomSheetDialog : BottomSheetDialogFragment() {
     protected lateinit var listener: HomeInteractListener
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        setStyle(DialogFragment.STYLE_NORMAL, R.style.DialogStyle)
-        return super.onCreateDialog(savedInstanceState)
-    }
-
     override fun onAttach(c: Context) {
         super.onAttach(c)
         try {

--- a/app/src/main/res/drawable/bottomsheet_background.xml
+++ b/app/src/main/res/drawable/bottomsheet_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/card_background"/>
+    <corners android:topLeftRadius="10dp" android:topRightRadius="10dp"/>
+</shape>

--- a/app/src/main/res/layout/dialog_bridge.xml
+++ b/app/src/main/res/layout/dialog_bridge.xml
@@ -3,8 +3,7 @@
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="@dimen/margin_medium"
-    android:orientation="vertical"
-    android:theme="@style/CardTheme">
+    android:orientation="vertical">
 
     <TextView
         android:layout_width="match_parent"
@@ -13,6 +12,7 @@
         android:textSize="24sp"
         app:fontFamily="@font/roboto_bold"
         android:textStyle="bold"
+        android:textColor="@color/daynight_textColor"
         android:text="Bridge">
 
     </TextView>
@@ -27,6 +27,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:textColor="@color/daynight_textColor"
+            android:textColorHint="@color/md_grey_500"
             android:hint="ESSID"
             />
         <Button
@@ -43,6 +44,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="2dp"
+        android:textColorHint="@color/md_grey_500"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/md_blue_600"
         >
@@ -51,7 +53,6 @@
             android:id="@+id/et_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:editable="true"
             android:fontFamily="sans-serif"
             android:hint="Password"
             android:textColor="@color/daynight_textColor"
@@ -65,6 +66,7 @@
         android:layout_height="wrap_content"
         android:fontFamily="sans-serif"
         android:hint="Hotspot ESSID"
+        android:textColorHint="@color/md_grey_500"
         android:textColor="@color/daynight_textColor"
         />
 
@@ -73,6 +75,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="2dp"
+        android:textColorHint="@color/md_grey_500"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/md_blue_600"
         >

--- a/app/src/main/res/layout/dialog_ethernet.xml
+++ b/app/src/main/res/layout/dialog_ethernet.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/padding_normal"
-    android:theme="@style/CardTheme">
+    android:padding="@dimen/padding_normal">
 
     <TextView
         android:layout_width="match_parent"
@@ -13,6 +12,7 @@
         android:textSize="24sp"
         app:fontFamily="@font/roboto_bold"
         android:textStyle="bold"
+        android:textColor="@color/daynight_textColor"
         android:text="Ethernet">
 
     </TextView>
@@ -22,6 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="IP"
+        android:textColorHint="@color/md_grey_500"
         android:padding="@dimen/padding_normal"
         android:textColor="@color/daynight_textColor"/>
 
@@ -31,6 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Mask"
+        android:textColorHint="@color/md_grey_500"
         android:padding="@dimen/padding_normal"
         android:textColor="@color/daynight_textColor"/>
 
@@ -39,6 +41,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Gateway"
+        android:textColorHint="@color/md_grey_500"
         android:padding="@dimen/padding_normal"
         android:textColor="@color/daynight_textColor"/>
 
@@ -47,6 +50,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="DNS"
+        android:textColorHint="@color/md_grey_500"
         android:padding="@dimen/padding_normal"
         android:textColor="@color/daynight_textColor"/>
 

--- a/app/src/main/res/layout/dialog_hotspot.xml
+++ b/app/src/main/res/layout/dialog_hotspot.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:padding="@dimen/margin_medium"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:theme="@style/CardTheme">
+    android:orientation="vertical">
 
     <TextView
         android:layout_width="match_parent"
@@ -13,6 +12,7 @@
         android:textSize="24sp"
         app:fontFamily="@font/roboto_bold"
         android:textStyle="bold"
+        android:textColor="@color/daynight_textColor"
         android:text="Hotspot">
 
     </TextView>
@@ -25,6 +25,7 @@
         android:hint="ESSID"
         android:inputType="textEmailAddress"
         android:padding="@dimen/margin_medium"
+        android:textColorHint="@color/md_grey_500"
         android:textColor="@color/daynight_textColor"/>
 
 
@@ -34,6 +35,7 @@
         android:layout_height="wrap_content"
         android:elevation="2dp"
         app:passwordToggleEnabled="true"
+        android:textColorHint="@color/md_grey_500"
         app:passwordToggleTint="@color/md_blue_600">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/dialog_wifi.xml
+++ b/app/src/main/res/layout/dialog_wifi.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/margin_medium"
-    android:theme="@style/CardTheme">
+    android:padding="@dimen/margin_medium">
 
     <TextView
         android:layout_width="match_parent"
@@ -13,6 +12,7 @@
         android:textSize="24sp"
         app:fontFamily="@font/roboto_bold"
         android:textStyle="bold"
+        android:textColor="@color/daynight_textColor"
         android:text="WiFi">
 
     </TextView>
@@ -29,6 +29,7 @@
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif"
             android:hint="SSID"
+            android:textColorHint="@color/md_grey_500"
             android:textColor="@color/daynight_textColor"
             android:inputType="textPersonName" />
 
@@ -50,6 +51,7 @@
         android:layout_marginEnd="@dimen/margin_huge"
         android:layout_marginRight="@dimen/margin_huge"
         android:visibility="gone"
+        android:textColorHint="@color/md_grey_500"
         app:passwordToggleTint="@color/md_blue_600">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -67,6 +69,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:passwordToggleEnabled="true"
+        android:textColorHint="@color/md_grey_500"
         app:passwordToggleTint="@color/md_blue_600">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -86,6 +86,7 @@
         <item name="android:itemTextAppearance">@style/MenuTextStyle</item>
         <item name="android:editTextColor">@color/daynight_textColor</item>
         <item name="alertDialogTheme">@style/CustomAlertDialogTheme</item>
+        <item name="bottomSheetDialogTheme">@style/CustomBottomSheetTheme</item>
     </style>
 
     <style name="AppSearchView" parent="Widget.AppCompat.SearchView" >
@@ -97,6 +98,16 @@
         <item name="android:textColor">@color/daynight_textColor</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="textColorAlertDialogListItem">@color/daynight_textColor</item>
+    </style>
+
+    <style name="CustomBottomSheetTheme"
+        parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/AppModalStyle</item>
+    </style>
+
+    <style name="AppModalStyle"
+        parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/bottomsheet_background</item>
     </style>
 
     <style name="MenuTextStyle">
@@ -166,10 +177,5 @@
         <item name="android:color">@color/bg_white</item>
         <item name="buttonTint">@color/bg_white</item>
         <item name="android:textColor">@color/bg_white</item>
-    </style>
-
-    <style name="DialogStyle" parent="Theme.Design.Light.BottomSheetDialog">
-        <item name="android:windowIsFloating">false</item>
-        <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -73,9 +73,7 @@
     <style name="FullscreenActionBarStyle" parent="Widget.AppCompat.ActionBar">
         <item name="android:background">@color/black_overlay</item>
     </style>
-
-    <style name="MyMaterialTheme" parent="MyMaterialTheme.Base"></style>
-
+    
     <style name="MyMaterialTheme.Base" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
@@ -86,6 +84,7 @@
         <item name="android:itemTextAppearance">@style/MenuTextStyle</item>
         <item name="android:editTextColor">@color/daynight_textColor</item>
         <item name="alertDialogTheme">@style/CustomAlertDialogTheme</item>
+        <item name="bottomSheetDialogTheme">@style/CustomBottomSheetTheme</item>
 
     </style>
 
@@ -98,6 +97,16 @@
         <item name="android:textColor">@color/daynight_textColor</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="textColorAlertDialogListItem">@color/daynight_textColor</item>
+    </style>
+
+    <style name="CustomBottomSheetTheme"
+        parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/AppModalStyle</item>
+    </style>
+
+    <style name="AppModalStyle"
+        parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/bottomsheet_background</item>
     </style>
 
     <style name="MenuTextStyle">
@@ -178,11 +187,6 @@
 
     <style name="KeyboardButton" parent="KeyboardKey">
         <item name="android:background">@drawable/keyboard_button_selector</item>
-    </style>
-
-    <style name="DialogStyle" parent="Theme.Design.Light.BottomSheetDialog">
-        <item name="android:windowIsFloating">false</item>
-        <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 
     <style name="tutorialTitle">


### PR DESCRIPTION
# fixes #1258 
<img width="440" alt="Screen Shot 2020-08-01 at 1 42 00 AM" src="https://user-images.githubusercontent.com/37857112/89095069-32439100-d398-11ea-82da-08361452f0e0.png">
<img width="439" alt="Screen Shot 2020-08-01 at 1 42 25 AM" src="https://user-images.githubusercontent.com/37857112/89095076-412a4380-d398-11ea-8e02-6ce958dc7d5b.png">
