### PR TITLE
home: no back error on dark mode

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/InitialActivity.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/InitialActivity.kt
@@ -3,6 +3,7 @@ package io.treehouses.remote
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Message
@@ -12,6 +13,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.GravityCompat
@@ -66,13 +68,15 @@ class InitialActivity : PermissionActivity(), NavigationView.OnNavigationItemSel
         bind.navView.setNavigationItemSelectedListener(this)
     }
 
-
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
     override fun onBackPressed() {
         if (bind.drawerLayout.isDrawerOpen(GravityCompat.START)) {
             bind.drawerLayout.closeDrawer(GravityCompat.START)
         } else {
             val f = supportFragmentManager.findFragmentById(R.id.fragment_container)
-            if (f is HomeFragment) finish()
+            if (f is HomeFragment) {
+                finishAffinity()
+            }
             else if (f is SettingsFragment || f is CommunityFragment) {
                 (supportFragmentManager).popBackStack()
                 title = currentTitle


### PR DESCRIPTION
### To test

1. Connect to RPi
2. Press back after connection succeeded
The app should close

There are 2 cases when reopening the app:
- RPi is still connected
- RPi is not connected