### PR TITLE
ssh: use string when refresh

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/SSHConfig.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/SSHConfig.kt
@@ -60,7 +60,7 @@ class SSHConfig : BaseFragment(), RVButtonClick, OnHostStatusChangedListener {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = DialogSshBinding.inflate(inflater, container, false)
         if (listener.getChatService().state == Constants.STATE_CONNECTED) {
-            listener.sendMessage("treehouses networkmode info")
+            listener.sendMessage(getString(R.string.TREEHOUSES_NETWORKMODE_INFO))
             listener.getChatService().updateHandler(mHandler)
         }
         return bind.root

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -35,7 +35,6 @@ class StatusFragment : BaseFragment() {
     private var deviceName = ""
     private var rpiVersion = ""
     private lateinit var bind: ActivityStatusFragmentBinding
-    private lateinit var refreshLayout: SwipeRefreshLayout
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityStatusFragmentBinding.inflate(inflater, container, false)
@@ -84,11 +83,10 @@ class StatusFragment : BaseFragment() {
     }
 
     private fun addRefreshListener(view: View) {
-        refreshLayout = view.findViewById<SwipeRefreshLayout?>(R.id.swiperefresh)!!
-        refreshLayout.setOnRefreshListener {
+        bind.swiperefresh.setOnRefreshListener {
             refresh()
         }
-        refreshLayout.setColorSchemeColors(
+        bind.swiperefresh.setColorSchemeColors(
                 ContextCompat.getColor(requireContext(), android.R.color.holo_red_light),
                 ContextCompat.getColor(requireContext(), android.R.color.holo_orange_light),
                 ContextCompat.getColor(requireContext(), android.R.color.holo_blue_light),
@@ -141,7 +139,7 @@ class StatusFragment : BaseFragment() {
             checkWifiStatus(statusData.internet)
 
             bind.refreshBtn.visibility = View.VISIBLE
-            refreshLayout.isRefreshing = false
+            bind.swiperefresh.isRefreshing = false
         } else checkUpgradeStatus(readMessage)
     }
 


### PR DESCRIPTION
- use view binding for refresh, instead of referencing via ID
- use string command to send network info command on SSH Config