### PR TITLE
services: add env button (fixes #1085)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/ServiceCardFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/ServiceCardFragment.kt
@@ -43,6 +43,7 @@ class ServiceCardFragment : Fragment(), View.OnClickListener {
             binding!!.installButton.setOnClickListener(this)
             binding!!.startButton.setOnClickListener(this)
             binding!!.openLink.setOnClickListener(this)
+            binding!!.editEnvButton.setOnClickListener(this)
             binding!!.autorunChecked.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean -> actionListener!!.onClickAutorun(serviceData, isChecked) }
         }
         return binding!!.root
@@ -73,10 +74,15 @@ class ServiceCardFragment : Fragment(), View.OnClickListener {
             visibility2 = View.VISIBLE
             visibility3 = View.VISIBLE
         }
+        var visibility4 = View.GONE
+
+        if (installed && !started && serviceData.usesEnv == "true")
+            visibility4 = View.VISIBLE
 
         binding!!.installButton.text = string2
         binding!!.startButton.visibility = visibility2
         binding!!.autorunChecked.visibility = visibility3
+        binding!!.editEnvButton.visibility = visibility4
 
     }
 
@@ -118,6 +124,8 @@ class ServiceCardFragment : Fragment(), View.OnClickListener {
             actionListener!!.onClickStart(serviceData)
         } else if (binding!!.openLink == v) {
             actionListener!!.onClickLink(serviceData)
+        } else if (binding!!.editEnvButton == v) {
+            actionListener!!.onClickEditEnvVar(serviceData)
         }
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/ServicesDetailsFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/ServicesDetailsFragment.kt
@@ -65,28 +65,35 @@ class ServicesDetailsFragment() : BaseServicesFragment(), OnItemSelectedListener
                     val output = msg.obj as String
                     if (wait) {
                         matchOutput(output.trim { it <= ' ' })
-                    } else if (isLocalUrl(output, received) || isTorURL(output, received)) {
-                        received = true
-                        openLocalURL(output.trim { it <= ' ' })
-                        binding.progressBar.visibility = View.GONE
-                    } else if (editEnv) {
-                        var tokens = output.split(" ")
-                        val name = tokens[2]
-                        tokens = tokens.subList(6, tokens.size-1)
-                        editEnv = false
-                        showEditDialog(name, tokens.size, tokens)
-                    } else {
-                        setScreenState(true)
-                        if (output.contains("service autorun set")) {
-                            Toast.makeText(context, "Switched autorun", Toast.LENGTH_SHORT).show()
-                        } else if (output.toLowerCase(Locale.ROOT).contains("error")) {
-                            Toast.makeText(context,"An Error occurred", Toast.LENGTH_SHORT).show()
-                        }
+                    }
+                    else{
+                        handleMore(output)
                     }
                 }
                 Constants.MESSAGE_STATE_CHANGE -> {
                     listener.redirectHome()
                 }
+            }
+        }
+    }
+
+    private fun handleMore(output:String){
+        if (isLocalUrl(output, received) || isTorURL(output, received)) {
+            received = true
+            openLocalURL(output.trim { it <= ' ' })
+            binding.progressBar.visibility = View.GONE
+        } else if (editEnv) {
+            var tokens = output.split(" ")
+            val name = tokens[2]
+            tokens = tokens.subList(6, tokens.size-1)
+            editEnv = false
+            showEditDialog(name, tokens.size, tokens)
+        } else {
+            setScreenState(true)
+            if (output.contains("service autorun set")) {
+                Toast.makeText(context, "Switched autorun", Toast.LENGTH_SHORT).show()
+            } else if (output.toLowerCase(Locale.ROOT).contains("error")) {
+                Toast.makeText(context,"An Error occurred", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/ServicesDetailsFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/ServicesDetailsFragment.kt
@@ -13,7 +13,9 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
+import com.google.android.material.textfield.TextInputEditText
 import io.treehouses.remote.Constants
 import io.treehouses.remote.R
 import io.treehouses.remote.Tutorials
@@ -23,6 +25,8 @@ import io.treehouses.remote.bases.BaseServicesFragment
 import io.treehouses.remote.callback.ServiceAction
 import io.treehouses.remote.databinding.ActivityServicesDetailsBinding
 import io.treehouses.remote.databinding.DialogChooseUrlBinding
+import io.treehouses.remote.databinding.EnvVarBinding
+import io.treehouses.remote.databinding.EnvVarItemBinding
 import io.treehouses.remote.pojo.ServiceInfo
 import java.util.*
 
@@ -33,6 +37,7 @@ class ServicesDetailsFragment() : BaseServicesFragment(), OnItemSelectedListener
     private var selected: ServiceInfo? = null
     private var serviceCardAdapter: ServiceCardAdapter? = null
     private var scrolled = false
+    private var editEnv = false
     private lateinit var binding: ActivityServicesDetailsBinding
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         mChatService = listener.getChatService()
@@ -64,6 +69,12 @@ class ServicesDetailsFragment() : BaseServicesFragment(), OnItemSelectedListener
                         received = true
                         openLocalURL(output.trim { it <= ' ' })
                         binding.progressBar.visibility = View.GONE
+                    } else if (editEnv) {
+                        var tokens = output.split(" ")
+                        val name = tokens[2]
+                        tokens = tokens.subList(6, tokens.size-1)
+                        editEnv = false
+                        showEditDialog(name, tokens.size, tokens)
                     } else {
                         setScreenState(true)
                         if (output.contains("service autorun set")) {
@@ -205,6 +216,38 @@ class ServicesDetailsFragment() : BaseServicesFragment(), OnItemSelectedListener
         }
     }
 
+    private fun showEditDialog(name: String, size: Int, vars: List<String>) {
+        val inflater = requireActivity().layoutInflater; val dialogBinding = EnvVarBinding.inflate(inflater)
+        for (i in 0 until size) {
+            val rowBinding = EnvVarItemBinding.inflate(inflater)
+            val envName = rowBinding.envName
+            val newVal = rowBinding.newVal
+
+            envName.text = vars[i].trim { it <= '\"'} + ":"
+            newVal.id = i
+            envName.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor)); newVal.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
+            dialogBinding.varList.addView(rowBinding.root)
+        }
+        val alertDialog = createEditDialog(dialogBinding.root, name, size, vars)
+        alertDialog.window!!.setBackgroundDrawableResource(android.R.color.transparent)
+        alertDialog.show()
+    }
+    private fun createEditDialog(view: View, name: String, size: Int, vars: List<String>): AlertDialog {
+        return AlertDialog.Builder(ContextThemeWrapper(activity, R.style.CustomAlertDialogStyle))
+                .setView(view).setTitle("Edit variables").setIcon(R.drawable.dialog_icon)
+                .setPositiveButton("Edit"
+                ) { _: DialogInterface?, _: Int ->
+                    var command = "treehouses services " + name + " config edit send"
+                    for (i in 0 until size) {
+                        command += " \"" + view.findViewById<TextInputEditText>(i).text + "\""
+                    }
+                    writeToRPI(command)
+                    Toast.makeText(context, "Environment variables changed", Toast.LENGTH_LONG).show()
+                }
+                .setNegativeButton(R.string.cancel) { dialog: DialogInterface, _: Int -> dialog.dismiss() }
+                .create()
+    }
+
     override fun onClickStart(s: ServiceInfo?) {
         onStart(s)
         wait = true
@@ -214,6 +257,11 @@ class ServicesDetailsFragment() : BaseServicesFragment(), OnItemSelectedListener
     override fun onClickLink(s: ServiceInfo?) {
         onLink(s)
         received = false
+    }
+
+    override fun onClickEditEnvVar(s: ServiceInfo?) {
+        editEnv = true
+        writeToRPI("treehouses services " + s!!.name + " config edit request")
     }
 
     override fun onClickAutorun(s: ServiceInfo?, newAutoRun: Boolean) {

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseServicesFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseServicesFragment.kt
@@ -74,7 +74,7 @@ open class BaseServicesFragment() : BaseFragment() {
             if (inServiceList(service, services) == -1) {
                 try {
                     services.add(ServiceInfo(service, servicesData!!.size[service]?.toInt()!!, ServiceInfo.SERVICE_AVAILABLE, servicesData!!.icon[service],
-                            servicesData!!.info[service], servicesData!!.autorun[service]))
+                            servicesData!!.info[service], servicesData!!.autorun[service], servicesData!!.usesEnv[service]))
                 } catch (exception:NullPointerException){
                     Log.e("Error", exception.toString())
                 }

--- a/app/src/main/kotlin/io/treehouses/remote/callback/ServiceAction.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/callback/ServiceAction.kt
@@ -7,4 +7,5 @@ interface ServiceAction {
     fun onClickStart(s: ServiceInfo?)
     fun onClickLink(s: ServiceInfo?)
     fun onClickAutorun(s: ServiceInfo?, newAutoRun: Boolean)
+    fun onClickEditEnvVar(s: ServiceInfo?)
 }

--- a/app/src/main/kotlin/io/treehouses/remote/pojo/ServiceInfo.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/pojo/ServiceInfo.kt
@@ -15,6 +15,8 @@ class ServiceInfo : Comparable<ServiceInfo>, Serializable {
     var info: String? = null
     @JvmField
     var autorun: String? = null
+    @JvmField
+    var usesEnv: String? = null
 
     //Headers
     constructor(n: String, status: Int) {
@@ -23,13 +25,14 @@ class ServiceInfo : Comparable<ServiceInfo>, Serializable {
     }
 
     //Services
-    constructor(name: String, size: Int, serviceStatus: Int, icon: String?, info: String?, autorun: String?) {
+    constructor(name: String, size: Int, serviceStatus: Int, icon: String?, info: String?, autorun: String?, usesEnv: String?) {
         this.name = name
         this.size = size
         this.serviceStatus = serviceStatus
         this.icon = icon
         this.info = info
         this.autorun = autorun
+        this.usesEnv = usesEnv
     }
 
     override fun compareTo(other: ServiceInfo): Int {

--- a/app/src/main/kotlin/io/treehouses/remote/pojo/ServicesData.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/pojo/ServicesData.kt
@@ -10,5 +10,6 @@ data class ServicesData(val available: List<String> = listOf(),
                         val icon: HashMap<String, String> = hashMapOf(),
                         val info: HashMap<String, String> = hashMapOf(),
                         val size: HashMap<String, String> = hashMapOf(),
-                        val autorun: HashMap<String, String> =hashMapOf()) : Serializable
+                        val autorun: HashMap<String, String> =hashMapOf(),
+                        val usesEnv: HashMap<String, String> =hashMapOf()) : Serializable
 

--- a/app/src/main/res/layout/env_var.xml
+++ b/app/src/main/res/layout/env_var.xml
@@ -1,0 +1,9 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/varList"
+    android:theme="@style/CardTheme"
+    android:layout_width="wrap_content"
+    android:paddingLeft="20dp"
+    android:paddingRight="20dp"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="20dp" />

--- a/app/src/main/res/layout/env_var_item.xml
+++ b/app/src/main/res/layout/env_var_item.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="50dp"
+    android:layout_width="match_parent"
+    android:weightSum="2">
+
+
+    <TextView
+        android:id="@+id/envName"
+        android:textColor="@color/daynight_textColor"
+        android:layout_width="0dp"
+        android:gravity="center_vertical"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:text="TextView" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:textColorHint="@color/expandable_child_text"
+        android:layout_weight="1">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/newVal"
+            android:textColor="@color/daynight_textColor"
+            android:gravity="center_vertical"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:hint="New Val" />
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/service_card.xml
+++ b/app/src/main/res/layout/service_card.xml
@@ -179,6 +179,21 @@
                 android:textColor="@color/bg_white"
                 android:background="@drawable/ripple"/>
 
+            <Button
+                android:id="@+id/editEnvButton"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:layout_gravity="center"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginLeft="@dimen/margin_large"
+                android:layout_marginTop="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginRight="@dimen/margin_large"
+                android:background="@drawable/service_button"
+                android:text="Edit Environment Variables"
+                android:textAllCaps="false"
+                android:textColor="@color/bg_white" />
+
         </LinearLayout>
     </FrameLayout>
 


### PR DESCRIPTION
Fixes #1085
## How to Test:

1. Run `treehouses upgrade cli` on raspberry pi
2. Checkout `services-env` branch on Android Studio.
3. Run app and go to services.
4. Tap on a service. There should be 4 different cases to look out for.
    - A service is not installed. It should not have the "edit env" button.
    - A service is installed but not running and does not have environment variables. It should not have the "edit env" button.
        - eg. turtleblocksjs, dokuwiki
    - A service is installed but not running and does have environment variables. It **should** have the "edit env" button.
        - eg. mongodb, librespeed
    - A service is running. It should not have the "edit env" button regardless if it uses env variables or not. 
5. For services where environment variables can be changed, click on the "edit env" button and you will be able to change the variables to different values. Click "Edit" to finish.
6. Run `treehouses services <service-name> config available` in terminal to see if changes are reflected.

_Note_: You can test this multiple ways. You can select each service one by one from the overview list. Or, you can change services from the drop down list in the details tab once you have already chosen a service.

![Screenshot_20200715-164053_Treehouses Remote](https://user-images.githubusercontent.com/44847682/87610376-0ba80980-c6ba-11ea-9c04-f295c4e9c55a.jpg)
