### PR TITLE
fixes app crash when switching to Dark mode (fixes #1412 #1419 #1457)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,7 @@
             android:label="Bluetooth Connection"
             android:enabled="true">
         </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/io/treehouses/remote/MainApplication.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/MainApplication.kt
@@ -1,6 +1,5 @@
 package io.treehouses.remote
 
-import android.app.Activity
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -9,7 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Build
-import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
@@ -35,26 +33,6 @@ class MainApplication : Application() {
                 .build()
         )
         SaveUtils.initCommandsList(applicationContext)
-        registerLifecycleCallbacks()
-    }
-
-    private fun registerLifecycleCallbacks() {
-        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
-            override fun onActivityPaused(activity: Activity) {}
-            override fun onActivityStarted(activity: Activity) {}
-            override fun onActivityDestroyed(activity: Activity) {
-                Log.e("ACTIVITY", "DESTROYED. Remaining: $numActivities")
-                numActivities--
-                if (numActivities <= 0) stopBluetoothService()
-            }
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
-            override fun onActivityStopped(activity: Activity) {}
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-                Log.e("ACTIVITY", "CREATED. Number: $numActivities")
-                numActivities++
-            }
-            override fun onActivityResumed(activity: Activity) {}
-        })
     }
 
     private val connection = object : ServiceConnection {
@@ -122,8 +100,5 @@ class MainApplication : Application() {
         var ratingDialog = true
 
         var mChatService : BluetoothChatService? = null
-
-        var numActivities = 0
-
     }
 }

--- a/app/src/main/res/xml/user_customization_preferences.xml
+++ b/app/src/main/res/xml/user_customization_preferences.xml
@@ -38,13 +38,13 @@
             android:summary="Delete all SSH keys">
         </Preference>
 
-        <SwitchPreference
-            android:title="Keep Bluetooth Alive"
-            android:key="keep_bluetooth_alive"
-            android:defaultValue="false"
-            android:layout="@layout/custom_pref_bottom"
-            android:summary="Keep Bluetooth service alive when Treehouses Remote is closed.">
-        </SwitchPreference>
+<!--        <SwitchPreference-->
+<!--            android:title="Keep Bluetooth Alive"-->
+<!--            android:key="keep_bluetooth_alive"-->
+<!--            android:defaultValue="false"-->
+<!--            android:layout="@layout/custom_pref_bottom"-->
+<!--            android:summary="Keep Bluetooth service alive when Treehouses Remote is closed.">-->
+<!--        </SwitchPreference>-->
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
# Fixes #1412 #1419 #1457 

- Bluetooth Notification shows a disconnect button now
- Removed the Keep alive settings in preferences
- App does not crash from switching from light mode to dark mode

Looks different on every system. On a Samsung, it looks like the following:
<img width="441" alt="Screen Shot 2020-08-24 at 6 29 02 PM" src="https://user-images.githubusercontent.com/37857112/91102711-b0adee80-e637-11ea-9d51-9c2e664c8ced.png">


