### PR TITLE
services: links clickable again (fixes #1431)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/ServiceCardFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/ServiceCardFragment.kt
@@ -107,8 +107,9 @@ class ServiceCardFragment : Fragment(), View.OnClickListener {
 
     private fun setServiceInfo(s: String?) {
         val spannableString = SpannableString(s)
+        Log.i("spannableString", " " + spannableString)
         Linkify.addLinks(spannableString, Linkify.ALL)
-        binding!!.serviceInfo.text = s
+        binding!!.serviceInfo.text = spannableString
         binding!!.serviceInfo.movementMethod = LinkMovementMethod.getInstance()
     }
 


### PR DESCRIPTION
fixes #1431 

## Description
Makes the links in the Services Info section clickable. 

## Screenshots

Before
![Screen Shot 2020-08-28 at 10 23 19 PM](https://user-images.githubusercontent.com/49795308/91628472-3c4bb600-e97d-11ea-8fb3-2e9b5c2b0aa1.png)

After
![Screen Shot 2020-08-28 at 10 19 32 PM](https://user-images.githubusercontent.com/49795308/91628474-41a90080-e97d-11ea-8d06-7f8e1fd946a4.png)
