### PR TITLE
tunnel: tor gitter button improved (fixes #1507)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -85,8 +85,8 @@ class TorTabFragment : BaseFragment() {
 
     private fun addNowButonListener() {
         nowButton!!.setOnClickListener {
-            nowButton!!.isEnabled = false
             listener.sendMessage(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW))
+            Toast.makeText(requireContext(), "The Gitter Channel has been notified.", Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
fixes #1507 

## Description
The gitter button would become disabled after the first use of it. There was faulty internal communication. Now, the gitter button isn't disabled; after pressed, it sends a toast message that the gitter channel has been notified. 

## Screenshots
![Screen Shot 2020-08-31 at 1 33 27 PM](https://user-images.githubusercontent.com/49795308/91759259-966f9580-eb8e-11ea-9973-ddc4c5469d3c.png)
