### PR TITLE
tunnel: dialog close buttons (fixes #1508, #1521)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -158,17 +158,17 @@ class TorTabFragment : BaseFragment() {
         addingPortButton.setOnClickListener {
             dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
             if (inputExternal.text.toString() !== "" && inputInternal.text.toString() !== "") {
-                val s1 = inputInternal.text.toString()
-                val s2 = inputExternal.text.toString()
+                val s1 = inputInternal.text.toString() ; val s2 = inputExternal.text.toString()
                 listener.sendMessage(getString(R.string.TREEHOUSES_TOR_ADD, s2, s1))
                 addPortButton!!.text = "Adding port, please wait for a while ............"
-                portList!!.isEnabled = false
-                addPortButton!!.isEnabled = false
+                portList!!.isEnabled = false; addPortButton!!.isEnabled = false
                 dialog.dismiss()
                 inputInternal.text?.clear(); inputExternal.text?.clear()
                 dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
             }
         }
+        val closeButton = dialog.findViewById<ImageButton>(R.id.closeButton)
+        closeButton.setOnClickListener { dialog.dismiss() }
     }
 
     private fun addStartButtonListener() {

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TunnelSSHFragment.kt
@@ -20,6 +20,9 @@ import io.treehouses.remote.databinding.ActivityTunnelSshFragmentBinding
 
 
 class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
+    lateinit var addPortCloseButton: ImageButton
+    lateinit var addHostCloseButton: ImageButton
+
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityTunnelSshFragmentBinding.inflate(inflater, container, false)
@@ -54,10 +57,11 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addHostButton!!.setOnClickListener(this)
         addingPortButton.setOnClickListener(this)
         addingHostButton.setOnClickListener(this)
+        addPortCloseButton.setOnClickListener(this)
+        addHostCloseButton.setOnClickListener(this)
         bind!!.notifyNow.setOnClickListener(this)
         bind!!.btnKeys.setOnClickListener(this)
     }
-
 
     @RequiresApi(Build.VERSION_CODES.N)
     private fun initializeDialog1() {
@@ -70,11 +74,11 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         inputInternal = dialog.findViewById(R.id.InternalTextInput)
         inputExternalHost = dialogHosts.findViewById(R.id.ExternalTextInput)
         inputInternalHost = dialogHosts.findViewById(R.id.InternalTextInput)
-        addingPortButton = dialog.findViewById<Button>(R.id.btn_adding_port)
-        addingHostButton = dialogHosts.findViewById<Button>(R.id.btn_adding_host)
-        portsName = ArrayList()
-        hostsName = ArrayList()
-        hostsPosition = ArrayList()
+        addingPortButton = dialog.findViewById(R.id.btn_adding_port)
+        addingHostButton = dialogHosts.findViewById(R.id.btn_adding_host)
+        addPortCloseButton = dialog.findViewById(R.id.addPortCloseButton)
+        addHostCloseButton = dialogHosts.findViewById(R.id.addHostCloseButton)
+        portsName = ArrayList(); hostsName = ArrayList(); hostsPosition = ArrayList()
         val window = dialog.window
         val windowHost = dialogHosts.window
         window!!.setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
@@ -231,11 +235,11 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 bind!!.notifyNow.isEnabled = false
                 listener.sendMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW))
             }
-
             R.id.btn_add_port -> showDialog(dialog)
             R.id.btn_add_hosts -> showDialog(dialogHosts)
             R.id.btn_keys -> showDialog(dialogKeys)
-            R.id.closeButton -> dialog.dismiss()
+            R.id.addPortCloseButton -> dialog.dismiss()
+            R.id.addHostCloseButton -> dialogHosts.dismiss()
         }
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TunnelSSHFragment.kt
@@ -3,7 +3,6 @@ package io.treehouses.remote.Fragments
 import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Context
-import android.content.DialogInterface
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
@@ -14,16 +13,10 @@ import android.util.Log
 import android.view.*
 import android.widget.*
 import androidx.annotation.RequiresApi
-import com.google.android.material.textfield.TextInputEditText
 import io.treehouses.remote.Constants
 import io.treehouses.remote.R
-import io.treehouses.remote.bases.BaseFragment
 import io.treehouses.remote.bases.BaseTunnelSSHFragment
 import io.treehouses.remote.databinding.ActivityTunnelSshFragmentBinding
-import io.treehouses.remote.utils.RESULTS
-import io.treehouses.remote.utils.match
-import org.json.JSONException
-import org.json.JSONObject
 
 
 class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
@@ -242,6 +235,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             R.id.btn_add_port -> showDialog(dialog)
             R.id.btn_add_hosts -> showDialog(dialogHosts)
             R.id.btn_keys -> showDialog(dialogKeys)
+            R.id.closeButton -> dialog.dismiss()
         }
     }
 

--- a/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
@@ -6,17 +6,40 @@
     android:padding="@dimen/margin_medium"
     android:background="@drawable/alertdialog_background">
 
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:textColor="@color/daynight_textColor"
-        android:textSize="24sp"
-        app:fontFamily="@font/roboto_bold"
-        android:textStyle="bold"
-        android:text="Adding Host">
+        android:layout_height="match_parent">
 
-    </TextView>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Adding Host"
+            android:textColor="@color/daynight_textColor"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            app:fontFamily="@font/roboto_bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+        </TextView>
+
+        <ImageButton
+            android:id="@+id/addHostCloseButton"
+            android:layout_width="30dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="304dp"
+            android:layout_marginLeft="304dp"
+            android:background="@null"
+            android:scaleType="fitEnd"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/textView2"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/tick_png" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_sshtunnel_ports.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_ports.xml
@@ -25,7 +25,7 @@
         </TextView>
 
         <ImageButton
-            android:id="@+id/closeButton"
+            android:id="@+id/addPortCloseButton"
             android:layout_width="30dp"
             android:layout_height="24dp"
             android:layout_marginStart="304dp"

--- a/app/src/main/res/layout/dialog_sshtunnel_ports.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_ports.xml
@@ -6,17 +6,40 @@
     android:padding="@dimen/margin_medium"
     android:background="@drawable/alertdialog_background">
 
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:textSize="24sp"
-        android:textColor="@color/daynight_textColor"
-        app:fontFamily="@font/roboto_bold"
-        android:textStyle="bold"
-        android:text="Adding Port">
+        android:layout_height="match_parent">
 
-    </TextView>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Adding Port"
+            android:textColor="@color/daynight_textColor"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            app:fontFamily="@font/roboto_bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+        </TextView>
+
+        <ImageButton
+            android:id="@+id/closeButton"
+            android:layout_width="30dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="304dp"
+            android:layout_marginLeft="304dp"
+            android:background="@null"
+            android:scaleType="fitEnd"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/textView2"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/tick_png" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_tor_ports.xml
+++ b/app/src/main/res/layout/dialog_tor_ports.xml
@@ -1,22 +1,45 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="350dp"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="@dimen/margin_medium"
     android:background="@drawable/alertdialog_background">
 
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:textSize="24sp"
-        android:textColor="@color/daynight_textColor"
-        app:fontFamily="@font/roboto_bold"
-        android:textStyle="bold"
-        android:text="Adding Port">
+        android:layout_height="match_parent">
 
-    </TextView>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Adding Port"
+            android:textColor="@color/daynight_textColor"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            app:fontFamily="@font/roboto_bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+        </TextView>
+
+        <ImageButton
+            android:id="@+id/closeButton"
+            android:layout_width="30dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="304dp"
+            android:layout_marginLeft="304dp"
+            android:background="@null"
+            android:scaleType="fitEnd"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@+id/textView2"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/tick_png" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1508 
Fixes #1521
## How to test:
1. Go to Tunnel
2. Add a port or host
3. The dialogs should now have close buttons.
![Screenshot_20200901-211852_Treehouses Remote](https://user-images.githubusercontent.com/44847682/91932994-b68d7a80-ec9c-11ea-8f69-b6cd96105e87.jpg)
![Screenshot_20200901-211858_Treehouses Remote](https://user-images.githubusercontent.com/44847682/91932995-b7261100-ec9c-11ea-88d3-2b1573f48233.jpg)
![Screenshot_20200901-211905_Treehouses Remote](https://user-images.githubusercontent.com/44847682/91932996-b7bea780-ec9c-11ea-8c42-e103997eccab.jpg)


