### PR TITLE
tunnel: better wording in tor (fixes #1516)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -119,7 +119,7 @@ class TorTabFragment : BaseFragment() {
             builder.setPositiveButton("Confirm") { dialog, _ ->
                 val msg = getString(R.string.TREEHOUSES_TOR_DELETE, portsName!![position].split(":".toRegex(), 2).toTypedArray()[0])
                 listener.sendMessage(msg)
-                addPortButton!!.text = "deleting port ....."
+                addPortButton!!.text = "Deleting port. Please wait..."
                 portList!!.isEnabled = false
                 addPortButton!!.isEnabled = false
                 dialog.dismiss()
@@ -157,7 +157,7 @@ class TorTabFragment : BaseFragment() {
                 val s1 = inputInternal.text.toString()
                 val s2 = inputExternal.text.toString()
                 listener.sendMessage(getString(R.string.TREEHOUSES_TOR_ADD, s2, s1))
-                addPortButton!!.text = "Adding port, please wait for a while ............"
+                addPortButton!!.text = "Adding port. Please wait..."
                 portList!!.isEnabled = false
                 addPortButton!!.isEnabled = false
                 dialog.dismiss()
@@ -176,7 +176,7 @@ class TorTabFragment : BaseFragment() {
             } else {
                 listener.sendMessage(getString(R.string.TREEHOUSES_TOR_START))
                 startButton!!.isEnabled = false
-                startButton!!.text = "Starting tor......"
+                startButton!!.text = "Starting Tor..."
             }
         }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -254,7 +254,7 @@ class TorTabFragment : BaseFragment() {
         } else if (readMessage.contains("the port has been added") || readMessage.contains("has been deleted")) {
             listener.sendMessage(getString(R.string.TREEHOUSES_TOR_PORTS))
             portsName = ArrayList()
-            addPortButton!!.text = "Retrieving port.... Please wait"
+            addPortButton!!.text = "Retrieving port. Please wait..."
             if (readMessage.contains("the port has been added")) {
                 Toast.makeText(requireContext(), "Port added. Retrieving ports list again", Toast.LENGTH_SHORT).show()
             } else if (readMessage.contains("has been deleted")) {


### PR DESCRIPTION
fixes #1516 

## Description
Fixes the action strings on the Tunnel page so that it matches other message structure. 

## Screenshots
Before
![Screen Shot 2020-08-31 at 1 45 22 PM](https://user-images.githubusercontent.com/49795308/91931861-dbd0b780-eca1-11ea-84bf-f90daf9e4d33.png)

After
![Screen Shot 2020-09-01 at 10 32 41 PM](https://user-images.githubusercontent.com/49795308/91932334-1555f280-eca3-11ea-84a7-74c4945f2191.png)
