### PR TITLE
home: no multiple asks for bluetooth sync

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/BaseHomeFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/BaseHomeFragment.kt
@@ -186,12 +186,13 @@ open class BaseHomeFragment : BaseFragment() {
      * @param serverHash : String = the hash of the server Bluetooth File
      */
     protected fun syncBluetooth(serverHash: String) {
+        logE("SERVER: $serverHash")
         //Get the local Bluetooth file on the app
         val inputStream = context?.assets?.open("bluetooth-server.txt")
         val localString = inputStream?.bufferedReader().use { it?.readText() }
         inputStream?.close()
         val hashed = Utils.hashString(localString!!)
-        logE("HASHED $serverHash")
+        logE("LOCAL: $serverHash")
         //Bluetooth file is outdated, but RPI is connected to the internet
         if (Matcher.isError(serverHash) && viewModel.internetStatus.value == true) {
             askForBluetoothUpgradeOverInternet()

--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
@@ -315,10 +315,6 @@ class HomeFragment : BaseHomeFragment() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshHandler()
-        if (viewModel.connectionStatus.value == Constants.STATE_CONNECTED) {
-            viewModel.checkVersionSent = true
-            viewModel.sendMessage(getString(R.string.TREEHOUSES_REMOTE_VERSION, BuildConfig.VERSION_CODE))
-        }
     }
 
     companion object {

--- a/app/src/main/res/values/commands.xml
+++ b/app/src/main/res/values/commands.xml
@@ -20,7 +20,7 @@
 
     <string name="TREEHOUSES_UPGRADE_CHECK">treehouses upgrade check\n</string>
     <string name="TREEHOUSES_UPGRADE">treehouses upgrade\n</string>
-    <string name="TREEHOUSES_UPGRADE_BLUETOOTH_MASTER">treehouses upgrade bluetooth master</string>
+    <string name="TREEHOUSES_UPGRADE_BLUETOOTH_MASTER">treehouses upgrade bluetooth master\n</string>
 
     <string name="TREEHOUSES_DEFAULT_NETWORK">treehouses default network\n</string>
     <string name="TREEHOUSES_RENAME">treehouses rename \"%1$s\"</string>


### PR DESCRIPTION
Please go to settings > Sync Bluetooth File With Local File

The Sync Bluetooth dialog always shows up because we are running `viewModel.sendMessage(getString(R.string.TREEHOUSES_REMOTE_VERSION, BuildConfig.VERSION_CODE))` in onResume. 

Removing this from onResume resolves the bug. 