### PR TITLE
services: no broken svg (fixes #1541)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/ui/services/ServicesViewModel.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/services/ServicesViewModel.kt
@@ -138,7 +138,7 @@ class ServicesViewModel(application: Application) : FragmentViewModel(applicatio
                 lives.forEach { it.value = Resource.nothing() }
             }
             editEnvAction.value?.status == LOADING && output.startsWith("treehouses services") -> editEnvAction.value = Resource.success(output.split(" ").toMutableList())
-            serverServiceData.value?.status == LOADING -> receiveJSON(output.trim())
+            serverServiceData.value?.status == LOADING -> receiveJSON(output)
             serviceAction.value?.status == LOADING && containsServiceAction(output) -> matchServiceAction(output.trim())
             autoRunAction.value?.status == LOADING && output.contains("service autorun set") -> {
                 autoRunAction.value = Resource.success(output.contains("true"))
@@ -157,7 +157,7 @@ class ServicesViewModel(application: Application) : FragmentViewModel(applicatio
      */
     private fun receiveJSON(current: String) {
         servicesJSON += current
-        if (currentlyReceivingJSON && servicesJSON.endsWith("}}")) {
+        if (currentlyReceivingJSON && servicesJSON.trim().endsWith("}}")) {
             try {
                 logE("GOT $servicesJSON")
                 val data = Gson().fromJson(servicesJSON, ServicesData::class.java)


### PR DESCRIPTION
# fixes #1541

- Fixes services SVGs so that none of them breaks anymore
## Goes from this
<img width="437" alt="Screen Shot 2020-09-03 at 1 23 44 AM" src="https://user-images.githubusercontent.com/37857112/92074449-1ca0fd00-ed84-11ea-94ce-cb329090e7b0.png">

## To this
<img width="437" alt="Screen Shot 2020-09-03 at 1 25 33 AM" src="https://user-images.githubusercontent.com/37857112/92074562-5d991180-ed84-11ea-9bfe-de942923ca06.png">
