### PR TITLE
home: only show dialog if device is not null (fixes #1553)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
@@ -94,7 +94,7 @@ class HomeFragment : BaseHomeFragment() {
             if (it == null) return@Observer
             connectionDialog?.dismiss()
             val noDialog = PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean(BluetoothFailedDialog.DONT_SHOW_DIALOG, false)
-            if (!noDialog) BluetoothFailedDialog().show(childFragmentManager, "ERROR")
+            if (!noDialog && viewModel.device != null) BluetoothFailedDialog().show(childFragmentManager, "ERROR")
             viewModel.errorConnecting.value = null
         })
     }
@@ -244,7 +244,7 @@ class HomeFragment : BaseHomeFragment() {
                     Tutorials.homeTutorials(bind, requireActivity())
                 }
                 Constants.STATE_CONNECTING -> {
-                    showBTConnectionDialog()
+                    if (viewModel.device != null) showBTConnectionDialog()
                 }
                 else -> {
                     viewModel.hashSent.value = Resource.nothing()
@@ -260,14 +260,14 @@ class HomeFragment : BaseHomeFragment() {
      */
     private fun showBTConnectionDialog() {
         connectionDialog = ProgressDialog(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle))
-        connectionDialog!!.setProgressStyle(ProgressDialog.STYLE_SPINNER)
-        connectionDialog!!.setTitle("Connecting...")
-        connectionDialog!!.setMessage("""
+        connectionDialog?.setProgressStyle(ProgressDialog.STYLE_SPINNER)
+        connectionDialog?.setTitle("Connecting...")
+        connectionDialog?.setMessage("""
     Device Name: ${viewModel.device?.name}
     Device Address: ${viewModel.device?.address}
     """.trimIndent())
-        connectionDialog!!.window!!.setBackgroundDrawableResource(android.R.color.transparent)
-        connectionDialog!!.show()
+        connectionDialog?.window!!.setBackgroundDrawableResource(android.R.color.transparent)
+        connectionDialog?.show()
     }
 
     /**


### PR DESCRIPTION
# fixes #1553 

Make sure device is not null when showing the connecting dialog and the connection failed dialog