### PR TITLE
system: share internet improvements (fixes #1563, #1576, #1577)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/SystemFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/SystemFragment.kt
@@ -1,14 +1,11 @@
 package io.treehouses.remote.Fragments
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
 import android.os.Message
 import android.text.format.Formatter
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -23,6 +20,7 @@ import io.treehouses.remote.adapter.ViewHolderVnc
 import io.treehouses.remote.bases.BaseFragment
 import io.treehouses.remote.databinding.ActivitySystemFragmentBinding
 import io.treehouses.remote.pojo.NetworkListItem
+import io.treehouses.remote.utils.DialogUtils
 import io.treehouses.remote.utils.logD
 import java.util.*
 
@@ -183,9 +181,15 @@ class SystemFragment : BaseFragment() {
             val diff = ArrayList<Long>()
             readMessageConditions(readMessage)
             logD("readMessage = $readMessage")
+            notifyUser(readMessage)
             vncToast(readMessage)
             checkAndPrefilIp(readMessage, diff)
         }
+    }
+
+    private fun notifyUser(msg: String) {
+        if (msg.contains("Error: password must have at least 8 characters")) Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+        else if (msg.contains("wifi is not connected")) DialogUtils.createAlertDialog4(context, "Wifi is not connected", "Check SSID and password and try again.")
     }
 
     private fun readMessageConditions(readMessage: String) {

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/ViewHolderTether.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/ViewHolderTether.kt
@@ -75,7 +75,7 @@ class ViewHolderTether internal constructor(v: View, listener: HomeInteractListe
             val password = editTextPassword?.text.toString()
             if (ssid.isNotEmpty()) {
                 listener.sendMessage(context.getString(R.string.TREEHOUSES_WIFI, ssid, if (password.isEmpty()) "" else password))
-                Toast.makeText(context, "Connecting...", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, "Connecting... This may take a few minutes", Toast.LENGTH_LONG).show()
             } else {
                 Toast.makeText(context, "Error: Invalid SSID", Toast.LENGTH_LONG).show()
             }

--- a/app/src/main/kotlin/io/treehouses/remote/utils/DialogUtils.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/utils/DialogUtils.kt
@@ -2,6 +2,7 @@ package io.treehouses.remote.utils
 
 import android.app.AlertDialog
 import android.content.Context
+import android.content.DialogInterface
 import android.view.ContextThemeWrapper
 import android.view.View
 import io.treehouses.remote.R
@@ -22,5 +23,11 @@ object DialogUtils {
 
     fun createAlertDialog3(context: Context?, mView: View?, icon: Int): AlertDialog.Builder {
         return createAlert(context).setView(mView).setIcon(icon)
+    }
+
+    fun createAlertDialog4(context: Context?, title: String, msg: String) {
+        createAlertDialog2(context, title, msg)
+                .setPositiveButton("OK") { dialog: DialogInterface?, _: Int -> dialog?.dismiss() }
+                .show().window!!.setBackgroundDrawableResource(android.R.color.transparent)
     }
 }


### PR DESCRIPTION
Fixes #1563 
Fixes #1576 
Fixes #1577

## How to test:
1. Go to system.
2. Go to `Share internet with pi (beta)`.
3. Go to `share internet using wifi` and enter a hotspot name and password and then connect. (the connecting toast should now notify the user it will take a couple of minutes)
4. Test out two cases.
    - The hotspot password is too short (less than 8 characters). There should now be a toast message saying it is too short.
    - The hotspot name name or password is invalid. There should now be a dialog notifying the user of this. Note it may take a couple of minutes to show up.

![Screenshot_20200907-141849_Treehouses Remote](https://user-images.githubusercontent.com/44847682/92417183-caf6ca80-f115-11ea-895a-ce2df27ec3f3.jpg)
![Screenshot_20200907-142026_Treehouses Remote](https://user-images.githubusercontent.com/44847682/92417185-cb8f6100-f115-11ea-8673-f4fa591ae4ce.jpg)