### PR TITLE
tunnel: tor delete all ports (fixes #1565)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -17,6 +17,7 @@ import io.treehouses.remote.R
 import io.treehouses.remote.adapter.TunnelPortAdapter
 import io.treehouses.remote.bases.BaseFragment
 import io.treehouses.remote.databinding.ActivityTorFragmentBinding
+import io.treehouses.remote.utils.DialogUtils
 import io.treehouses.remote.utils.Utils
 import io.treehouses.remote.utils.logD
 import io.treehouses.remote.utils.logE
@@ -113,37 +114,26 @@ class TorTabFragment : BaseFragment() {
         }
     }
 
-    private fun promptDeleteAllPorts(builder: AlertDialog.Builder) {
-        builder.setTitle("Delete All Ports?")
-        builder.setPositiveButton("Yes") { dialog, _ ->
-            listener.sendMessage(getString(R.string.TREEHOUSES_TOR_DELETE_ALL))
-            dialog.dismiss()
-        }
-        builder.setNegativeButton("No", null)
+    private fun promptDeleteAllPorts() {
+        DialogUtils.createAlertDialog(context, "Delete All Ports?") { listener.sendMessage(getString(R.string.TREEHOUSES_TOR_DELETE_ALL)) }
     }
 
-    private fun promptDeletePort(builder: AlertDialog.Builder, position: Int) {
-        builder.setTitle("Delete Port " + portsName!![position] + " ?")
-        builder.setPositiveButton("Confirm") { dialog, _ ->
+    private fun promptDeletePort(position: Int) {
+        DialogUtils.createAlertDialog(context, "Delete Port " + portsName!![position] + " ?")
+        {
             val msg = getString(R.string.TREEHOUSES_TOR_DELETE, portsName!![position].split(":".toRegex(), 2).toTypedArray()[0])
             listener.sendMessage(msg)
             addPortButton!!.text = "Deleting port. Please wait..."
             portList!!.isEnabled = false
             addPortButton!!.isEnabled = false
-            dialog.dismiss()
         }
-        builder.setNegativeButton("Cancel", null)
     }
 
     private fun addPortListListener() {
         portList!!.onItemClickListener = OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->
-            val builder = AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle))
             val deleteAllPortsButtonSelected = portsName!!.size > 1 && position == portsName!!.size-1
-            if (deleteAllPortsButtonSelected) promptDeleteAllPorts(builder)
-            else promptDeletePort(builder, position)
-            val dialog = builder.create()
-            dialog.window!!.setBackgroundDrawableResource(android.R.color.transparent)
-            dialog.show()
+            if (deleteAllPortsButtonSelected) promptDeleteAllPorts()
+            else promptDeletePort(position)
         }
 
         bind!!.btnAddPort

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -10,7 +10,6 @@ import android.os.Message
 import android.view.*
 import android.widget.*
 import android.widget.AdapterView.OnItemClickListener
-import androidx.core.view.size
 import com.google.android.material.textfield.TextInputEditText
 import io.treehouses.remote.Constants
 import io.treehouses.remote.Network.BluetoothChatService
@@ -112,28 +111,34 @@ class TorTabFragment : BaseFragment() {
         }
     }
 
+    private fun promptDeleteAllPorts(builder: AlertDialog.Builder) {
+        builder.setTitle("Delete All Ports?")
+        builder.setPositiveButton("Yes") { dialog, _ ->
+            listener.sendMessage(getString(R.string.TREEHOUSES_TOR_DELETE_ALL))
+            dialog.dismiss()
+        }
+        builder.setNegativeButton("No", null)
+    }
+
+    private fun promptDeletePort(builder: AlertDialog.Builder, position: Int) {
+        builder.setTitle("Delete Port " + portsName!![position] + " ?")
+        builder.setPositiveButton("Confirm") { dialog, _ ->
+            val msg = getString(R.string.TREEHOUSES_TOR_DELETE, portsName!![position].split(":".toRegex(), 2).toTypedArray()[0])
+            listener.sendMessage(msg)
+            addPortButton!!.text = "Deleting port. Please wait..."
+            portList!!.isEnabled = false
+            addPortButton!!.isEnabled = false
+            dialog.dismiss()
+        }
+        builder.setNegativeButton("Cancel", null)
+    }
+
     private fun addPortListListener() {
         portList!!.onItemClickListener = OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->
             val builder = AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle))
-            if (portList!!.size > 1 && position == portList!!.size-1) {
-                builder.setTitle("Delete All Ports?")
-                builder.setPositiveButton("Yes") { dialog, _ ->
-                    listener.sendMessage(getString(R.string.TREEHOUSES_TOR_DELETE_ALL))
-                    dialog.dismiss()
-                }
-                builder.setNegativeButton("No", null)
-            } else {
-                builder.setTitle("Delete Port " + portsName!![position] + " ?")
-                builder.setPositiveButton("Confirm") { dialog, _ ->
-                    val msg = getString(R.string.TREEHOUSES_TOR_DELETE, portsName!![position].split(":".toRegex(), 2).toTypedArray()[0])
-                    listener.sendMessage(msg)
-                    addPortButton!!.text = "Deleting port. Please wait..."
-                    portList!!.isEnabled = false
-                    addPortButton!!.isEnabled = false
-                    dialog.dismiss()
-                }
-                builder.setNegativeButton("Cancel", null)
-            }
+            val deleteAllPortsButtonSelected = portsName!!.size > 1 && position == portsName!!.size-1
+            if (deleteAllPortsButtonSelected) promptDeleteAllPorts(builder)
+            else promptDeletePort(builder, position)
             val dialog = builder.create()
             dialog.window!!.setBackgroundDrawableResource(android.R.color.transparent)
             dialog.show()
@@ -144,7 +149,6 @@ class TorTabFragment : BaseFragment() {
         addPortButton = bind!!.btnAddPort
         startButton!!.isEnabled = false
         startButton!!.text = "Getting Tor Status from raspberry pi"
-
     }
 
 

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -248,7 +248,7 @@ class TorTabFragment : BaseFragment() {
                 if(i == ports.size - 1) break
                 portsName!!.add(ports[i])
             }
-            if (portsName!!.size > 1) portsName!!.add("")
+            if (portsName!!.size > 1) portsName!!.add("Delete All Ports")
             adapter = TunnelPortAdapter(requireContext(), portsName!!)
             val portList = requireView().findViewById<ListView>(R.id.portList)
             portList.adapter = adapter

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -26,6 +26,7 @@ class TorTabFragment : BaseFragment() {
     private var nowButton: Button? = null
     private var startButton: Button? = null
     private var addPortButton: Button? = null
+    private var deletePortsButton: Button? = null
     private var portsName: ArrayList<String>? = null
     private var adapter: ArrayAdapter<String>? = null
     private var hostName:String = ""
@@ -97,6 +98,7 @@ class TorTabFragment : BaseFragment() {
         bind!!.btnAddPort
         startButton = bind!!.btnTorStart
         addPortButton = bind!!.btnAddPort
+        deletePortsButton = bind!!.btnDeletePorts
         startButton!!.isEnabled = false
         startButton!!.text = "Getting Tor Status from raspberry pi"
 
@@ -150,6 +152,9 @@ class TorTabFragment : BaseFragment() {
             dialog.window!!.setBackgroundDrawableResource(android.R.color.transparent)
             dialog.show() }
 
+        deletePortsButton!!.setOnClickListener {
+            listener.sendMessage(getString(R.string.TREEHOUSES_TOR_DELETE_ALL))
+        }
         val addingPortButton = dialog.findViewById<Button>(R.id.btn_adding_port)
         addingPortButton.setOnClickListener {
             dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
@@ -260,6 +265,9 @@ class TorTabFragment : BaseFragment() {
             } else if (readMessage.contains("has been deleted")) {
                 Toast.makeText(requireContext(), "Port deleted. Retrieving ports list again", Toast.LENGTH_SHORT).show()
             } else handleFurtherMessages(readMessage)
+        } else if (readMessage.contains("ports have been deleted")) {
+            listener.sendMessage(getString(R.string.TREEHOUSES_TOR_PORTS))
+            portsName = ArrayList()
         }
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -14,6 +14,7 @@ import com.google.android.material.textfield.TextInputEditText
 import io.treehouses.remote.Constants
 import io.treehouses.remote.Network.BluetoothChatService
 import io.treehouses.remote.R
+import io.treehouses.remote.adapter.TunnelPortAdapter
 import io.treehouses.remote.bases.BaseFragment
 import io.treehouses.remote.databinding.ActivityTorFragmentBinding
 import io.treehouses.remote.utils.Utils
@@ -27,7 +28,7 @@ class TorTabFragment : BaseFragment() {
     private var startButton: Button? = null
     private var addPortButton: Button? = null
     private var portsName: ArrayList<String>? = null
-    private var adapter: ArrayAdapter<String>? = null
+    private var adapter: TunnelPortAdapter? = null
     private var hostName:String = ""
     private var myClipboard: ClipboardManager? = null
     private var myClip: ClipData? = null
@@ -39,7 +40,7 @@ class TorTabFragment : BaseFragment() {
         mChatService!!.updateHandler(mHandler)
         listener.sendMessage(getString(R.string.TREEHOUSES_TOR_PORTS))
         portsName = ArrayList()
-        adapter = ArrayAdapter(requireContext(), android.R.layout.select_dialog_item, portsName!!)
+        adapter = TunnelPortAdapter(requireContext(), portsName!!)
         bind = ActivityTorFragmentBinding.inflate(inflater, container, false)
         bind!!.btnHostName.visibility = View.GONE
         addHostNameButonListener()
@@ -248,7 +249,7 @@ class TorTabFragment : BaseFragment() {
                 portsName!!.add(ports[i])
             }
             if (portsName!!.size > 1) portsName!!.add("")
-            adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item, portsName!!)
+            adapter = TunnelPortAdapter(requireContext(), portsName!!)
             val portList = requireView().findViewById<ListView>(R.id.portList)
             portList.adapter = adapter
             listener.sendMessage(getString(R.string.TREEHOUSES_TOR_STATUS))
@@ -260,7 +261,7 @@ class TorTabFragment : BaseFragment() {
             addPortButton!!.text = "Add Port"
             portList!!.isEnabled = true; addPortButton!!.isEnabled = true
             portsName = ArrayList()
-            adapter = ArrayAdapter(requireContext(), android.R.layout.select_dialog_item, portsName!!)
+            adapter = TunnelPortAdapter(requireContext(), portsName!!)
             val portList = requireView().findViewById<ListView>(R.id.portList)
             portList.adapter = adapter
             listener.sendMessage(getString(R.string.TREEHOUSES_TOR_STATUS))

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/TorTabFragment.kt
@@ -253,7 +253,7 @@ class TorTabFragment : BaseFragment() {
                 if (i == ports.size - 1) break
                 portsName!!.add(ports[i])
             }
-            if (portsName!!.size > 1) portsName!!.add("Delete All Ports")
+            if (portsName!!.size > 1) portsName!!.add("All")
             try { adapter = TunnelPortAdapter(requireContext(), portsName!!) } catch (e: Exception) { logE(e.toString()) }
             val portList = requireView().findViewById<ListView>(R.id.portList)
             portList.adapter = adapter

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/TunnelPortAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/TunnelPortAdapter.kt
@@ -1,0 +1,24 @@
+package io.treehouses.remote.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import io.treehouses.remote.R
+
+
+class TunnelPortAdapter(private val mContext: Context, private val data: List<String?>) : ArrayAdapter<String?>(mContext, 0, data) {
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+
+        var convertedView: View
+        val deleteAllPortsButtonSelected = data.size > 1 && position == data.size-1
+        convertedView = if (deleteAllPortsButtonSelected) LayoutInflater.from(mContext).inflate(R.layout.select_dialog_item_delete_all, parent, false)
+        else LayoutInflater.from(mContext).inflate(R.layout.select_dialog_item, parent, false)
+        val text = convertedView as TextView
+        text.text = getItem(position)
+        // Return the completed view to render on screen
+        return convertedView
+    }
+}

--- a/app/src/main/kotlin/io/treehouses/remote/utils/DialogUtils.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/utils/DialogUtils.kt
@@ -25,9 +25,19 @@ object DialogUtils {
         return createAlert(context).setView(mView).setIcon(icon)
     }
 
+    fun createAlertDialog(context: Context?, title: String, myFunc: () -> Unit) {
+        createAdvancedDialog(createAlertDialog(context, title), myFunc)
+    }
+
     fun createAlertDialog(context: Context?, title: String, msg: String, myFunc: () -> Unit) {
-        createAlertDialog(context, title, msg)
-                .setPositiveButton("YES") { _: DialogInterface?, _: Int -> myFunc() }
+        createAdvancedDialog(createAlertDialog(context, title, msg), myFunc)
+    }
+
+    private fun createAdvancedDialog(builder: AlertDialog.Builder, myFunc: () -> Unit) {
+        builder.setPositiveButton("YES") { dialog: DialogInterface?, _: Int ->
+            myFunc()
+            dialog?.dismiss()
+        }
                 .setNegativeButton("NO") { dialog: DialogInterface?, _: Int -> dialog?.dismiss()}
                 .show().window!!.setBackgroundDrawableResource(android.R.color.transparent)
     }

--- a/app/src/main/res/drawable/delete_all_icon.xml
+++ b/app/src/main/res/drawable/delete_all_icon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:drawable="@drawable/ic_delete_black_24dp"
+        android:width="28dp"
+        android:height="28dp"
+        />
+
+</layer-list >

--- a/app/src/main/res/layout/activity_tor_fragment.xml
+++ b/app/src/main/res/layout/activity_tor_fragment.xml
@@ -90,16 +90,34 @@
 
     </LinearLayout>
 
-    <LinearLayout  android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <Button
-            android:id="@+id/btn_add_port"
-            android:layout_width="0dp"
+            android:id="@+id/btn_delete_ports"
+            android:layout_width="match_parent"
             android:layout_height="35dp"
             android:layout_marginStart="25dp"
             android:layout_marginLeft="25dp"
             android:layout_marginTop="30dp"
+            android:layout_marginEnd="25dp"
+            android:layout_marginRight="8dp"
+
+            android:layout_weight="1"
+            android:background="@drawable/ic_red"
+            android:text="@string/delete_ports"
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            android:textColor="@color/bg_white" />
+
+        <Button
+            android:id="@+id/btn_add_port"
+            android:layout_width="match_parent"
+            android:layout_height="35dp"
+            android:layout_marginStart="25dp"
+            android:layout_marginLeft="25dp"
+            android:layout_marginTop="10dp"
             android:layout_marginEnd="25dp"
             android:layout_marginRight="8dp"
             android:layout_marginBottom="20dp"
@@ -109,16 +127,17 @@
             android:text="@string/add_port"
             android:textAppearance="@style/TextAppearance.AppCompat.Small"
             android:textColor="@color/bg_white" />
+
     </LinearLayout>
 
     <ListView
         android:id="@+id/portList"
-        android:background="#00FFFFFF"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginStart="25dp"
         android:layout_marginEnd="25dp"
-        android:fadeScrollbars="false"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:background="#00FFFFFF"
+        android:fadeScrollbars="false" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_tor_fragment.xml
+++ b/app/src/main/res/layout/activity_tor_fragment.xml
@@ -90,34 +90,16 @@
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+    <LinearLayout  android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <Button
-            android:id="@+id/btn_delete_ports"
-            android:layout_width="match_parent"
+            android:id="@+id/btn_add_port"
+            android:layout_width="0dp"
             android:layout_height="35dp"
             android:layout_marginStart="25dp"
             android:layout_marginLeft="25dp"
             android:layout_marginTop="30dp"
-            android:layout_marginEnd="25dp"
-            android:layout_marginRight="8dp"
-
-            android:layout_weight="1"
-            android:background="@drawable/ic_red"
-            android:text="@string/delete_ports"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small"
-            android:textColor="@color/bg_white" />
-
-        <Button
-            android:id="@+id/btn_add_port"
-            android:layout_width="match_parent"
-            android:layout_height="35dp"
-            android:layout_marginStart="25dp"
-            android:layout_marginLeft="25dp"
-            android:layout_marginTop="10dp"
             android:layout_marginEnd="25dp"
             android:layout_marginRight="8dp"
             android:layout_marginBottom="20dp"
@@ -127,7 +109,6 @@
             android:text="@string/add_port"
             android:textAppearance="@style/TextAppearance.AppCompat.Small"
             android:textColor="@color/bg_white" />
-
     </LinearLayout>
 
     <ListView

--- a/app/src/main/res/layout/select_dialog_item_delete_all.xml
+++ b/app/src/main/res/layout/select_dialog_item_delete_all.xml
@@ -7,7 +7,7 @@
     android:textAppearance="?android:attr/textAppearanceLarge"
     android:textColor="@color/daynight_textColor"
     android:gravity="center_vertical"
-    android:drawableRight="@drawable/tick"
+    android:drawableRight="@drawable/delete_all_icon"
     android:paddingRight="0dip"
     android:ellipsize="marquee"
     />

--- a/app/src/main/res/layout/select_dialog_item_delete_all.xml
+++ b/app/src/main/res/layout/select_dialog_item_delete_all.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:textAppearance="?android:attr/textAppearanceLarge"
+    android:textColor="@color/daynight_textColor"
+    android:gravity="center_vertical"
+    android:drawableRight="@drawable/tick"
+    android:paddingRight="0dip"
+    android:ellipsize="marquee"
+    />

--- a/app/src/main/res/values-night/strings.xml
+++ b/app/src/main/res/values-night/strings.xml
@@ -238,6 +238,7 @@
 
     <string name="start_tor">Start Tor</string>
     <string name="add_port">Add Port</string>
+    <string name="delete_ports">Delete All Ports</string>
     <string name="notification">Notification: </string>
 
     <string-array name="dark_mode_options">

--- a/app/src/main/res/values/commands.xml
+++ b/app/src/main/res/values/commands.xml
@@ -51,6 +51,7 @@
     <string name="TREEHOUSES_TOR_NOTICE_OFF">treehouses tor notice off</string>
     <string name="TREEHOUSES_TOR_NOTICE_NOW">treehouses tor notice now</string>
     <string name="TREEHOUSES_TOR_DELETE">treehouses tor delete \"%1$s\"</string>
+    <string name="TREEHOUSES_TOR_DELETE_ALL">treehouses tor deleteall</string>
     <string name="TREEHOUSES_TOR_START">treehouses tor start</string>
     <string name="TREEHOUSES_TOR_STOP">treehouses tor stop</string>
     <string name="TREEHOUSES_TOR_ADD">treehouses tor add \"%1$s\" \"%2$s\"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,7 @@
 
     <string name="start_tor">Start Tor</string>
     <string name="add_port">Add Port</string>
+    <string name="delete_ports">Delete All Ports</string>
     <string name="notification">Notification: </string>
 
     <string-array name="dark_mode_options">


### PR DESCRIPTION
Fixes #1565 

## How to test:
1. Go to tunnel.
2. Add two ports if you dont have any, as the `delete all ports` functionality only appears when there are at least 2 ports.
3. There should now be `delete all ports` at the bottom of the listview.
4. Test to see if this works and if this button scales with different number of ports in the list.
![Screenshot_20200911-201618_Treehouses Remote](https://user-images.githubusercontent.com/44847682/92985951-1558ae00-f46c-11ea-9eeb-f337081fb82f.jpg)

![Screenshot_20200911-184307_Treehouses Remote](https://user-images.githubusercontent.com/44847682/92984422-d6702b80-f45e-11ea-96e1-9465b676ee56.jpg)

