### PR TITLE
status: check for wifi country before cli version (fixes #1570)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -60,7 +60,7 @@ class StatusFragment : BaseStatusFragment() {
         return bind.root
     }
 
-    override fun wifiCountry(adapter:ArrayAdapter<String?>){
+    fun wifiCountry(adapter:ArrayAdapter<String?>){
         val dialog = Dialog(requireContext())
         dialog.setContentView(R.layout.dialog_wificountry)
         dialog.countries

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -36,6 +36,8 @@ class StatusFragment : BaseStatusFragment() {
 
     private var lastCommand = ""
     private var deviceName = ""
+    private var statInt = ""
+
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityStatusFragmentBinding.inflate(inflater, container, false)
@@ -122,6 +124,7 @@ class StatusFragment : BaseStatusFragment() {
 
         if(lastCommand == requireActivity().getString(R.string.TREEHOUSES_REMOTE_STATUSPAGE)){
             val statusData = Gson().fromJson(readMessage, StatusData::class.java)
+            statInt = statusData.internet
 
             bind.temperature.text = statusData.temperature + "°C"
             ObjectAnimator.ofInt(bind.temperatureBar, "progress", (statusData.temperature.toFloat() / 80 * 100).toInt()).setDuration(600).start()
@@ -206,6 +209,7 @@ class StatusFragment : BaseStatusFragment() {
      * The Handler that gets information back from the BluetoothChatService
      */
     override fun getMessage(msg: Message) {
+
         when (msg.what) {
             Constants.MESSAGE_STATE_CHANGE -> checkStatusNow()
             Constants.MESSAGE_WRITE -> {
@@ -216,7 +220,7 @@ class StatusFragment : BaseStatusFragment() {
             Constants.MESSAGE_READ -> {
                 val readMessage = msg.obj as String
                 logE("$TAG, readMessage = $readMessage")
-                receiveMessage(readMessage)
+                receiveMessage(readMessage, statInt)
             }
         }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -52,7 +52,6 @@ class StatusFragment : BaseStatusFragment() {
         deviceName = mChatService.connectedDeviceName
 
 
-
         checkStatusNow()
 
         refresh()

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -39,11 +39,6 @@ class StatusFragment : BaseStatusFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityStatusFragmentBinding.inflate(inflater, container, false)
-        mChatService = listener.getChatService()
-        mChatService.updateHandler(mHandler)
-        deviceName = mChatService.connectedDeviceName
-
-        checkStatusNow()
         val countriesCode = Locale.getISOCountries()
         val countriesName = arrayOfNulls<String>(countriesCode.size)
         for (i in countriesCode.indices) {
@@ -52,13 +47,21 @@ class StatusFragment : BaseStatusFragment() {
         val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
         bind.countryDisplay.isEnabled = false
         bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
+        mChatService = listener.getChatService()
+        mChatService.updateHandler(mHandler)
+        deviceName = mChatService.connectedDeviceName
+
+
+
+        checkStatusNow()
+
         refresh()
         bind.refreshBtn.setOnClickListener { refresh() }
 
         return bind.root
     }
 
-    private fun wifiCountry(adapter:ArrayAdapter<String?>){
+    override fun wifiCountry(adapter:ArrayAdapter<String?>){
         val dialog = Dialog(requireContext())
         dialog.setContentView(R.layout.dialog_wificountry)
         dialog.countries
@@ -142,7 +145,12 @@ class StatusFragment : BaseStatusFragment() {
 
             updateStatusPage(statusData)
 
-        } else checkUpgradeStatus(readMessage)
+
+
+        } else {
+
+            checkUpgradeStatus(readMessage)
+        }
     }
 
     override fun checkWifiStatus(readMessage: String) {

--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/StatusFragment.kt
@@ -42,9 +42,8 @@ class StatusFragment : BaseStatusFragment() {
         mChatService = listener.getChatService()
         mChatService.updateHandler(mHandler)
         deviceName = mChatService.connectedDeviceName
+
         checkStatusNow()
-        refresh()
-        bind.refreshBtn.setOnClickListener { refresh() }
         val countriesCode = Locale.getISOCountries()
         val countriesName = arrayOfNulls<String>(countriesCode.size)
         for (i in countriesCode.indices) {
@@ -53,6 +52,9 @@ class StatusFragment : BaseStatusFragment() {
         val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
         bind.countryDisplay.isEnabled = false
         bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
+        refresh()
+        bind.refreshBtn.setOnClickListener { refresh() }
+
         return bind.root
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
@@ -71,41 +71,25 @@ open class BaseStatusFragment : BaseFragment() {
 
     fun updateStatusPage(statusData: StatusData) {
         val res = statusData.status.trim().split(" ")
-
+        checkWifiStatus(statusData.internet)
+        writeToRPI(requireActivity().getString(R.string.TREEHOUSES_WIFI_COUNTRY_CHECK))
         bind.imageText.text = String.format("Image Version: %s", res[2].substring(8))
         bind.deviceAddress.text = res[1]
         bind.tvRpiType.text = "Model: " + res[4]
         rpiVersion = res[3]
 
+
+
         bind.remoteVersionText.text = "Remote Version: " + BuildConfig.VERSION_NAME
 
-        checkWifiStatus(statusData.internet)
+
 
         bind.refreshBtn.visibility = View.VISIBLE
         bind.swiperefresh.isRefreshing = false
-        writeToRPI(requireActivity().getString(R.string.TREEHOUSES_WIFI_COUNTRY_CHECK))
+
 
     }
-    open fun wifiCountry(adapter:ArrayAdapter<String?>){
-        val dialog = Dialog(requireContext())
-        dialog.setContentView(R.layout.dialog_wificountry)
-        dialog.countries
-        countryList = dialog.countries
-        adapter.filter.filter("")
-        countryList!!.adapter = adapter
-        countryList!!.isTextFilterEnabled = true
-        countryList!!.onItemClickListener = AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, p: Int, _: Long ->
-            var selectedString = countryList!!.getItemAtPosition(p).toString()
-            selectedString = selectedString.substring(selectedString.length - 4, selectedString.length - 2)
-            writeToRPI(requireContext().resources.getString(R.string.TREEHOUSES_WIFI_COUNTRY, selectedString))
-            bind.countryDisplay.isEnabled = false
-            bind.countryDisplay.setText("Changing country")
-            dialog.dismiss()
-        }
 
-        searchView(dialog)
-        dialog.show()
-    }
     open fun checkWifiStatus(readMessage: String) {}
 
     fun writeNetworkInfo(networkMode:String, readMessage: String) {
@@ -131,14 +115,6 @@ open class BaseStatusFragment : BaseFragment() {
     open fun writeToRPI(ping: String) {}
 
     fun checkUpgradeStatus(readMessage: String) {
-        val countriesCode = Locale.getISOCountries()
-        val countriesName = arrayOfNulls<String>(countriesCode.size)
-        for (i in countriesCode.indices) {
-            countriesName[i] = getCountryName(countriesCode[i])
-        }
-        val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
-        bind.countryDisplay.isEnabled = false
-        bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
         checkUpgradeNow()
         if (readMessage.startsWith("false ") && readMessage.length < 14) {
             bind.upgradeCheck.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.tick))
@@ -163,15 +139,6 @@ open class BaseStatusFragment : BaseFragment() {
 
     fun refresh() {
         setChecking()
-        val countriesCode = Locale.getISOCountries()
-        val countriesName = arrayOfNulls<String>(countriesCode.size)
-        for (i in countriesCode.indices) {
-            countriesName[i] = getCountryName(countriesCode[i])
-        }
-        val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
-        bind.countryDisplay.isEnabled = false
-        bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
-
         writeToRPI(requireActivity().getString(R.string.TREEHOUSES_REMOTE_STATUSPAGE))
         bind.refreshBtn.visibility = View.GONE
         bind.countryDisplay.visibility = View.GONE

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
@@ -163,6 +163,15 @@ open class BaseStatusFragment : BaseFragment() {
 
     fun refresh() {
         setChecking()
+        val countriesCode = Locale.getISOCountries()
+        val countriesName = arrayOfNulls<String>(countriesCode.size)
+        for (i in countriesCode.indices) {
+            countriesName[i] = getCountryName(countriesCode[i])
+        }
+        val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
+        bind.countryDisplay.isEnabled = false
+        bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
+
         writeToRPI(requireActivity().getString(R.string.TREEHOUSES_REMOTE_STATUSPAGE))
         bind.refreshBtn.visibility = View.GONE
         bind.countryDisplay.visibility = View.GONE

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
@@ -48,12 +48,13 @@ open class BaseStatusFragment : BaseFragment() {
         })
     }
 
-    fun receiveMessage(readMessage: String){
+    fun receiveMessage(readMessage: String, statInt : String){
         if (readMessage.startsWith("country=") || readMessage.contains("set to")) {
             val len = readMessage.length - 3
             val country = readMessage.substring(len).trim { it <= ' ' }
             bind.countryDisplay.setText(getCountryName(country))
             bind.countryDisplay.isEnabled = true
+            checkWifiStatus(statInt)
         } else if (readMessage.contains("Error when")) {
             bind.countryDisplay.setText("Try again")
             bind.countryDisplay.isEnabled = true
@@ -71,7 +72,7 @@ open class BaseStatusFragment : BaseFragment() {
 
     fun updateStatusPage(statusData: StatusData) {
         val res = statusData.status.trim().split(" ")
-        checkWifiStatus(statusData.internet)
+       // checkWifiStatus(statusData.internet)
         writeToRPI(requireActivity().getString(R.string.TREEHOUSES_WIFI_COUNTRY_CHECK))
         bind.imageText.text = String.format("Image Version: %s", res[2].substring(8))
         bind.deviceAddress.text = res[1]


### PR DESCRIPTION
fixes #1570 

## Description
On the status page, treehouses now checks for the wifi country before the cli upgrade to speed up the process of getting the user their status. 

## Screenshot
![Screen Shot 2020-09-11 at 10 51 49 PM](https://user-images.githubusercontent.com/49795308/92987697-23b1c480-f482-11ea-9f6f-af7fd5467776.png)
