### PR TITLE
options: auto open community (fixes #1602)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/InitialActivity.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/InitialActivity.kt
@@ -169,15 +169,20 @@ class InitialActivity : BaseInitialActivity() {
                 if (!preferences?.getBoolean("send_log", false)!!) {
                     val builder = DialogUtils.createAlertDialog(this@InitialActivity, "Sharing is Caring.", "The community map is only available with data sharing. " +
                             "Please enable data sharing to access this feature.", v).setCancelable(false)
-                    DialogUtils.createAdvancedDialog(builder, Pair("Enable Data Sharing", "Cancel"), { preferences!!.edit().putBoolean("send_log", true).apply() }, {MainApplication.showLogDialog = false })
+                    DialogUtils.createAdvancedDialog(builder, Pair("Enable Data Sharing", "Cancel"), {
+                        preferences!!.edit().putBoolean("send_log", true).apply()
+                        goToCommunity()
+                    }, {MainApplication.showLogDialog = false })
                 }
-                else {
-                    openCallFragment(CommunityFragment())
-                    title = getString(R.string.action_community)
-                }
+                else { goToCommunity() }
             }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun goToCommunity() {
+        openCallFragment(CommunityFragment())
+        title = getString(R.string.action_community)
     }
 
     fun changeAppBar() {


### PR DESCRIPTION
Fixes #1602 

## How to test:
1. Have data sharing disabled in settings.
2. Go to community.
3. Click enable data sharing in dialog.
4. Community should now automatically open.
![Screenshot_20200916-162219_Treehouses Remote](https://user-images.githubusercontent.com/44847682/93402182-e27e3380-f838-11ea-98d6-66ffca224bb8.jpg)
