### PR TITLE
refactor TerminalView remove warnings

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/SSH/Terminal/BaseTerminalView.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/SSH/Terminal/BaseTerminalView.kt
@@ -50,7 +50,7 @@ open class BaseTerminalView(context: Context, bridge: TerminalBridge, pager: Ter
     }
 
 
-    override fun onFontSizeChanged(sizeDp: Float) {}
+    override fun onFontSizeChanged(size: Float) {}
 
 
     init {


### PR DESCRIPTION
Renamed super method parameter to be the same as overridden one.

![2020-09-30](https://user-images.githubusercontent.com/44847682/94750624-580af900-033b-11eb-825e-6642f4c12d08.png)
