### PR TITLE
tunnel: rounding socks profile dialog corners (fixes #1647)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Fragments/SocksFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Fragments/SocksFragment.kt
@@ -64,7 +64,7 @@ class SocksFragment : BaseFragment() {
         val window = dialog.window
         window!!.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
-
+        window.setBackgroundDrawableResource(android.R.color.transparent)
     }
     private fun addPortListListener() {
         portList!!.onItemClickListener = OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->


### PR DESCRIPTION
Fixes #1647
![Screenshot_20200930-172020_Treehouses Remote](https://user-images.githubusercontent.com/44847682/94753058-ea160000-0341-11eb-9a12-fac6f4a75d03.jpg)
