### PR TITLE
status: refresh activates when data loaded (fixes #1611)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
@@ -55,6 +55,7 @@ open class BaseStatusFragment : BaseFragment() {
             val country = readMessage.substring(len).trim { it <= ' ' }
             bind.countryDisplay.setText(getCountryName(country))
             bind.countryDisplay.isEnabled = true
+            bind.refreshBtn.visibility = View.VISIBLE
         } else if (readMessage.contains("Error when")) {
             bind.countryDisplay.setText("Try again")
             bind.countryDisplay.isEnabled = true
@@ -82,9 +83,11 @@ open class BaseStatusFragment : BaseFragment() {
 
         checkWifiStatus(statusData.internet)
 
-        bind.refreshBtn.visibility = View.VISIBLE
+
         bind.swiperefresh.isRefreshing = false
         writeToRPI(requireActivity().getString(R.string.TREEHOUSES_WIFI_COUNTRY_CHECK))
+
+
 
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseStatusFragment.kt
@@ -83,11 +83,8 @@ open class BaseStatusFragment : BaseFragment() {
 
         checkWifiStatus(statusData.internet)
 
-
         bind.swiperefresh.isRefreshing = false
         writeToRPI(requireActivity().getString(R.string.TREEHOUSES_WIFI_COUNTRY_CHECK))
-
-
 
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
@@ -39,7 +39,7 @@ class StatusFragment : BaseStatusFragment() {
         mChatService.updateHandler(mHandler)
         deviceName = mChatService.connectedDeviceName
         checkStatusNow()
-        refresh()
+        refresh ()
         bind.refreshBtn.setOnClickListener { refresh() }
         val countriesCode = Locale.getISOCountries()
         val countriesName = arrayOfNulls<String>(countriesCode.size)
@@ -49,6 +49,7 @@ class StatusFragment : BaseStatusFragment() {
         val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
         bind.countryDisplay.isEnabled = false
         bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
+
         return bind.root
     }
 
@@ -136,12 +137,16 @@ class StatusFragment : BaseStatusFragment() {
 
             updateStatusPage(statusData)
 
+
+
         } else checkUpgradeStatus(readMessage)
     }
 
     override fun checkWifiStatus(readMessage: String) {
         if (readMessage.startsWith("true")) {
             writeToRPI(requireActivity().getString(R.string.TREEHOUSES_UPGRADE_CHECK))
+
+
         } else {
             bind.tvUpgradeCheck.text = "      NO INTERNET"
             bind.upgrade.visibility = View.GONE

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
@@ -142,8 +142,6 @@ class StatusFragment : BaseStatusFragment() {
     override fun checkWifiStatus(readMessage: String) {
         if (readMessage.startsWith("true")) {
             writeToRPI(requireActivity().getString(R.string.TREEHOUSES_UPGRADE_CHECK))
-
-
         } else {
             bind.tvUpgradeCheck.text = "      NO INTERNET"
             bind.upgrade.visibility = View.GONE

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/StatusFragment.kt
@@ -39,7 +39,7 @@ class StatusFragment : BaseStatusFragment() {
         mChatService.updateHandler(mHandler)
         deviceName = mChatService.connectedDeviceName
         checkStatusNow()
-        refresh ()
+        refresh()
         bind.refreshBtn.setOnClickListener { refresh() }
         val countriesCode = Locale.getISOCountries()
         val countriesName = arrayOfNulls<String>(countriesCode.size)
@@ -49,7 +49,6 @@ class StatusFragment : BaseStatusFragment() {
         val adapter = ArrayAdapter(requireContext(), R.layout.select_dialog_item_countries, countriesName)
         bind.countryDisplay.isEnabled = false
         bind.countryDisplay.setOnClickListener{ wifiCountry(adapter) }
-
         return bind.root
     }
 
@@ -136,8 +135,6 @@ class StatusFragment : BaseStatusFragment() {
             bind.tvRpiName.text = "Hostname: " + statusData.hostname
 
             updateStatusPage(statusData)
-
-
 
         } else checkUpgradeStatus(readMessage)
     }


### PR DESCRIPTION
fixes #1611 

## Description
Allow all elements to load before the refresh button is visible. 

## Screenshots (the refresh button is only visible after wifi country)
![Screen Shot 2020-10-30 at 10 30 50 PM](https://user-images.githubusercontent.com/49795308/97771147-92fd7980-1aff-11eb-8a90-df225a77e3c7.png)
