### PR TITLE
tunnel: delete false sshport keeps button active (fixes #1641)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -241,7 +241,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
 
     protected fun handleHostNotFound() {
         addHostButton?.isEnabled = true; portList?.isEnabled = true; addHostButton?.isEnabled = true
-        addHostButton?.text = "Add Host"; addPortButton?.text = "Add Port"
+        addHostButton?.text = "Add Host"; addPortButton?.text = "Add Port"; addPortButton?.isEnabled = true
         Toast.makeText(requireContext(), "incorrect deleting host/port, try again", Toast.LENGTH_SHORT).show()
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -242,7 +242,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected fun handleHostNotFound() {
         addHostButton?.isEnabled = true; portList?.isEnabled = true; addHostButton?.isEnabled = true
         addHostButton?.text = "Add Host"; addPortButton?.text = "Add Port"; addPortButton?.isEnabled = true
-        Toast.makeText(requireContext(), "Host not found. Try again.", Toast.LENGTH_SHORT).show()
+        Toast.makeText(requireContext(), "Host not found. Failure to delete port.", Toast.LENGTH_SHORT).show()
     }
 
     protected fun handleModifiedList() {

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -242,7 +242,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected fun handleHostNotFound() {
         addHostButton?.isEnabled = true; portList?.isEnabled = true; addHostButton?.isEnabled = true
         addHostButton?.text = "Add Host"; addPortButton?.text = "Add Port"; addPortButton?.isEnabled = true
-        Toast.makeText(requireContext(), "incorrect deleting host/port, try again", Toast.LENGTH_SHORT).show()
+        Toast.makeText(requireContext(), "Host not found. Try again.", Toast.LENGTH_SHORT).show()
     }
 
     protected fun handleModifiedList() {


### PR DESCRIPTION
fixes #1641 

## Description
Before, the add port button would not be enabled after failing to delete a port. 
Now, it is enabled after the "incorrect port" toast text is shown. 

![Screen Shot 2020-11-06 at 7 53 03 PM](https://user-images.githubusercontent.com/49795308/98430322-c09b7300-2069-11eb-86e6-70e7462f81f4.png)

![Screen Shot 2020-11-06 at 7 53 13 PM](https://user-images.githubusercontent.com/49795308/98430329-c4c79080-2069-11eb-81f8-27e781c43610.png)
