### PR TITLE
tunnel: clearer ssh error messages (fixes #1667)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -242,7 +242,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected fun handleHostNotFound() {
         addHostButton?.isEnabled = true; portList?.isEnabled = true; addHostButton?.isEnabled = true
         addHostButton?.text = "Add Host"; addPortButton?.text = "Add Port"
-        Toast.makeText(requireContext(), "incorrect deleting host/port, try again", Toast.LENGTH_SHORT).show()
+        Toast.makeText(requireContext(), "Host not found. Failure to delete port.", Toast.LENGTH_SHORT).show()
     }
 
     protected fun handleModifiedList() {


### PR DESCRIPTION
fixes #1667 

## Description
Error message wasn't clear, and prompted user to try again although that could lead the app to crashing. Now, it says "host not found"

## Screenshots
![Screen Shot 2020-11-06 at 7 53 03 PM](https://user-images.githubusercontent.com/49795308/98430676-7b2c7500-206c-11eb-8ce0-b6ccf3757337.png)

![Screen Shot 2020-11-06 at 8 11 36 PM](https://user-images.githubusercontent.com/49795308/98430656-4c160380-206c-11eb-9a4e-af66ef8db9b8.png)
