### PR TITLE
tunnel: tor tutorial added (fixes #1678)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Tutorials.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Tutorials.kt
@@ -98,6 +98,17 @@ object Tutorials {
         show(a)
     }
 
+    fun tunnelTorTutorials(bind: ActivityTorFragmentBinding, activity: FragmentActivity)
+    {
+        if (!SaveUtils.getFragmentFirstTime(activity, SaveUtils.Screens.TUNNEL)) return
+        SaveUtils.setFragmentFirstTime(activity, SaveUtils.Screens.TUNNEL, false)
+
+        val a = fancyShowCaseViewRoundedRect(activity, bind.btnTorStart, "Stop or Start Tor")
+        val b = fancyShowCaseViewRoundedRect(activity, bind.notifyNow, "Notify the Gitter Channel")
+        val c = fancyShowCaseViewRoundedRect(activity, bind.btnAddPort, "Add Tor Ports")
+        show(a, b, c)
+    }
+
 //    fun tunnelTutorials(bind: ActivityTunnelSshFragmentBinding, activity: FragmentActivity) {
 //        //if (!SaveUtils.getFragmentFirstTime(activity, SaveUtils.Screens.TUNNEL)) return
 //        //SaveUtils.setFragmentFirstTime(activity, SaveUtils.Screens.TUNNEL, false)

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TorTabFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TorTabFragment.kt
@@ -13,6 +13,7 @@ import android.widget.AdapterView.OnItemClickListener
 import com.google.android.material.textfield.TextInputEditText
 import io.treehouses.remote.Constants
 import io.treehouses.remote.R
+import io.treehouses.remote.Tutorials
 import io.treehouses.remote.adapter.TunnelPortAdapter
 import io.treehouses.remote.bases.BaseTorTabFragment
 import io.treehouses.remote.databinding.ActivityTorFragmentBinding
@@ -49,6 +50,10 @@ class TorTabFragment : BaseTorTabFragment() {
         return bind!!.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bind?.let { Tutorials.tunnelTorTutorials(it, requireActivity()) }
+    }
     private fun addHostNameButonListener() {
         bind!!.btnHostName.setOnClickListener {
             val builder = AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle))


### PR DESCRIPTION
fixes #1678 

## Description
Adds a tutorial in the Tor tunnel tab for first time users 

## Screenshots
![Screen Shot 2020-11-18 at 7 28 26 PM](https://user-images.githubusercontent.com/49795308/99613134-3ee60680-29d4-11eb-84ca-056e1a668d42.png)
