### PR TITLE
terminal: transparent divider color (fixes #1650)

### DIFF
--- a/app/src/main/res/drawable/ic_white.xml
+++ b/app/src/main/res/drawable/ic_white.xml
@@ -1,8 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-
     <solid android:color="@color/bg_white"/>
-
     <size android:height="1dp" />
-
 </shape>

--- a/app/src/main/res/drawable/ic_white.xml
+++ b/app/src/main/res/drawable/ic_white.xml
@@ -1,0 +1,8 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/bg_white"/>
+
+    <size android:height="1dp" />
+
+</shape>

--- a/app/src/main/res/layout/activity_terminal_fragment.xml
+++ b/app/src/main/res/layout/activity_terminal_fragment.xml
@@ -135,8 +135,12 @@
         android:layout_marginBottom="100dp"
         android:background="@color/windowBackground"
         android:descendantFocusability="beforeDescendants"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="3dp" />
+        android:dividerHeight="3dp"
+        android:divider="@drawable/ic_white"
+        android:childDivider="@drawable/ic_white"
+            />
+<!--        android:divider="@color/windowBackground"-->
+
 
     <ProgressBar
         android:id="@+id/progressBar"

--- a/app/src/main/res/layout/activity_terminal_fragment.xml
+++ b/app/src/main/res/layout/activity_terminal_fragment.xml
@@ -137,10 +137,7 @@
         android:descendantFocusability="beforeDescendants"
         android:dividerHeight="3dp"
         android:divider="@drawable/ic_white"
-        android:childDivider="@drawable/ic_white"
-            />
-<!--        android:divider="@color/windowBackground"-->
-
+        android:childDivider="@drawable/ic_white"/>
 
     <ProgressBar
         android:id="@+id/progressBar"


### PR DESCRIPTION
fixes #1650 

## Description
Terminal command list divider color now appears transparent 

## Screenshot
Before:
![image](https://user-images.githubusercontent.com/49795308/100489985-1bf2db00-30d5-11eb-8848-71779267608c.png)

After:
![Screen Shot 2020-11-27 at 5 20 25 PM](https://user-images.githubusercontent.com/49795308/100489949-d7ffd600-30d4-11eb-8a42-2b4b0bb36503.png)
