### PR TITLE
sshtunnel: allow users to delete ports (fixes #1700)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -133,7 +133,9 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 logD("dasda ${myPos.toString()}")
                 val portName = TunnelUtils.getPortName(portsName, position)
                 val formatArgs = portName + " " + hostsName!![myPos].split(":")[0]
-                writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_PORT, formatArgs))
+                val message = "treehouses sshtunnel remove port "
+                val command = buildString { append(message); append(formatArgs) }
+                writeMessage(command)
                 addPortButton!!.text = "deleting port ....."
                 portList!!.isEnabled = false; addPortButton!!.isEnabled = false
             }

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -132,8 +132,9 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 if (hostsPosition!!.last() < position) myPos = hostsPosition!!.lastIndex
                 logD("dasda ${myPos.toString()}")
                 val portName = TunnelUtils.getPortName(portsName, position)
-                val formatArgs = portName + " " + hostsName!![myPos].split(":")[0]
-                val command = buildString { append(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC); append(formatArgs) }
+                val formatArgs = " " + portName + " " + hostsName!![myPos].split(":")[0]
+                val command = buildString { append(getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC)); append(formatArgs) }
+                logD(command)
                 writeMessage(command)
                 addPortButton!!.text = "deleting port ....."
                 portList!!.isEnabled = false; addPortButton!!.isEnabled = false

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -133,8 +133,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 logD("dasda ${myPos.toString()}")
                 val portName = TunnelUtils.getPortName(portsName, position)
                 val formatArgs = portName + " " + hostsName!![myPos].split(":")[0]
-                val message = "treehouses sshtunnel remove port "
-                val command = buildString { append(message); append(formatArgs) }
+                val command = buildString { append("treehouses sshtunnel remove port "); append(formatArgs) }
                 writeMessage(command)
                 addPortButton!!.text = "deleting port ....."
                 portList!!.isEnabled = false; addPortButton!!.isEnabled = false

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -133,7 +133,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 logD("dasda ${myPos.toString()}")
                 val portName = TunnelUtils.getPortName(portsName, position)
                 val formatArgs = portName + " " + hostsName!![myPos].split(":")[0]
-                val command = buildString { append("treehouses sshtunnel remove port "); append(formatArgs) }
+                val command = buildString { append(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC); append(formatArgs) }
                 writeMessage(command)
                 addPortButton!!.text = "deleting port ....."
                 portList!!.isEnabled = false; addPortButton!!.isEnabled = false

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -134,7 +134,6 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 val portName = TunnelUtils.getPortName(portsName, position)
                 val formatArgs = " " + portName + " " + hostsName!![myPos].split(":")[0]
                 val command = buildString { append(getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC)); append(formatArgs) }
-                logD(command)
                 writeMessage(command)
                 addPortButton!!.text = "deleting port ....."
                 portList!!.isEnabled = false; addPortButton!!.isEnabled = false

--- a/app/src/main/res/values/commands.xml
+++ b/app/src/main/res/values/commands.xml
@@ -70,7 +70,7 @@
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_HOST">treehouses sshtunnel remove host \"%1$s\" </string>
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_PORT">treehouses sshtunnel remove port \"%1$s\" </string>
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_ALL">treehouses sshtunnel remove all</string>
-    <string name="TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC">treehouses sshtunnel remove port</string>
+    <string name="TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC">treehouses sshtunnel remove port </string>
 
     <string name="TREEHOUSES_SSH_2FA">treehouses ssh 2fa"</string>
     <string name="TREEHOUSES_SSH_2FA_ADD">treehouses ssh 2fa add \"%1$s\"</string>

--- a/app/src/main/res/values/commands.xml
+++ b/app/src/main/res/values/commands.xml
@@ -41,6 +41,7 @@
     <string name="TREEHOUSES_DISCOVER_GATEWAY_LIST">treehouses discover gateway list\n</string>
     <string name="TREEHOUSES_DISCOVER_SELF">treehouses discover self\n</string>
 
+
     <string name="TREEHOUSES_WIFI_ENTERPRISE">treehouses wifi \"%1$s\" \"%2$s\" \"%3$s\"\n</string>
     <string name="TREEHOUSES_WIFI_HIDDEN_ENTERPRISE">treehouses wifihidden \"%1$s\" \"%2$s\" \"%3$s\"\n</string>
 
@@ -69,6 +70,7 @@
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_HOST">treehouses sshtunnel remove host \"%1$s\" </string>
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_PORT">treehouses sshtunnel remove port \"%1$s\" </string>
     <string name="TREEHOUSES_SSHTUNNEL_REMOVE_ALL">treehouses sshtunnel remove all</string>
+    <string name="TREEHOUSES_SSHTUNNEL_REMOVE_PORT_SPECIFIC">treehouses sshtunnel remove port</string>
 
     <string name="TREEHOUSES_SSH_2FA">treehouses ssh 2fa"</string>
     <string name="TREEHOUSES_SSH_2FA_ADD">treehouses ssh 2fa add \"%1$s\"</string>


### PR DESCRIPTION
fixes #1700 

## Description
Allow users to delete ssh ports. Before, it would throw an error saying host/port not found. Now, it can delete. 