### PR TITLE
ssh: removed beta from title (fixes #1730)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="menu_system">System</string>
     <string name="menu_terminal">Terminal</string>
     <string name="menu_services">Services</string>
-    <string name="menu_ssh">SSH (Beta)</string>
+    <string name="menu_ssh">SSH</string>
     <string name="menu_ssh_tunnel">Tunnel</string>
     <string name="menu_about">About</string>
     <string name="menu_status">Status</string>


### PR DESCRIPTION
fixes #1730 

### Description
update ssh string to remove beta title