### PR TITLE
ssh: back button directs to ssh overview (fixes #1708)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/sshconsole/SSHConsole.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/sshconsole/SSHConsole.kt
@@ -192,10 +192,8 @@ open class SSHConsole : DerivedSSHConsole(), BridgeDisconnectedListener {
         if (item == null) return false
         return when (item.itemId) {
             android.R.id.home -> {
-                val intent = Intent(this, InitialActivity::class.java)
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                startActivity(intent)
-                true
+                finish()
+                return true
             }
             else -> super.onOptionsItemSelected(item)
         }


### PR DESCRIPTION
fixes #1708

Description
fixed terminal back button so that it returns to the ssh page, and not the home page.