### PR TITLE
sshtunnel: host enables gitter notify button (fixes #1738)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -257,6 +257,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
         addPortButton?.isEnabled = true
         addPortButton?.text = "Add Port"; addHostButton?.text = "Add Host"
         addPortButton!!.isEnabled = true; addHostButton?.isEnabled = true
+        bind!!.notifyNow.isEnabled = true
         val hosts = readMessage.split('\n')
         for (host in hosts) {
             val ports = host.split(' ')

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -29,7 +29,6 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
     lateinit var addPortCloseButton: ImageButton
     lateinit var addHostCloseButton: ImageButton
     lateinit var addKeyCloseButton: ImageButton
-    lateinit var notifyButton: Button
 
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -40,7 +39,6 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         initializeDialog1()
         addPortButton = bind!!.btnAddPort
         addHostButton = bind!!.btnAddHosts
-        notifyButton = bind!!.notifyNow
         arrayOf("1", "2", "three")
         hostsName = ArrayList()
         val adapter: ArrayAdapter<String> = ArrayAdapter(this.requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
@@ -48,7 +46,6 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addListeners()
         addInfoListener()
         addPortListListener()
-        addNotifyButtonListener()
         return bind!!.root
     }
 
@@ -77,7 +74,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addPortButton!!.setOnClickListener(this); addHostButton!!.setOnClickListener(this)
         addingPortButton.setOnClickListener(this); addingHostButton.setOnClickListener(this)
         addPortCloseButton.setOnClickListener(this); addHostCloseButton.setOnClickListener(this)
-        addKeyCloseButton.setOnClickListener(this); notifyButton.setOnClickListener(this)
+        addKeyCloseButton.setOnClickListener(this); bind!!.notifyNow.setOnClickListener(this)
         bind!!.btnKeys.setOnClickListener(this)
     }
 
@@ -206,7 +203,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, s1, s2))
                 addHostButton!!.text = "Adding......"
                 addHostButton!!.isEnabled = false
-                notifyButton!!.isEnabled = true
+                bind!!.notifyNow.isEnabled = true
             } else Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
             dialogHosts.dismiss()
         }
@@ -224,20 +221,14 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         }
     }
 
-    private fun addNotifyButtonListener() {
-        val messages = Pair(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW), "The Gitter Channel has been notified.")
-        notifyButton!!.setOnClickListener {
-            Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
-        }
-    }
-
     override fun onClick(v: View?) {
         fun showDialog(dialog: Dialog) { dialog.window!!.setBackgroundDrawableResource(android.R.color.transparent); dialog.show() }
         when (v?.id) {
             R.id.btn_adding_host -> addingHostButton()
             R.id.btn_adding_port -> addingPortButton()
             R.id.notify_now -> {
-                bind!!.notifyNow.isEnabled = false
+                val messages = Pair(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW), "The Gitter Channel has been notified.")
+                Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW))
             }
             R.id.btn_add_port -> showDialog(dialog)

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -197,7 +197,6 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, s1, s2))
                 addHostButton!!.text = "Adding......"
                 addHostButton!!.isEnabled = false
-                bind!!.notifyNow.isEnabled = true
             } else Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
             dialogHosts.dismiss()
         }

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -220,7 +220,8 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             R.id.btn_adding_host -> addingHostButton()
             R.id.btn_adding_port -> addingPortButton()
             R.id.notify_now -> {
-                val messages = Pair(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW), "The Gitter Channel has been notified.")
+                val toast = "The Gitter Channel has been notified."
+                val messages = Pair(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW), toast)
                 Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
         }
             R.id.btn_add_port -> showDialog(dialog)

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -220,10 +220,9 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             R.id.btn_adding_host -> addingHostButton()
             R.id.btn_adding_port -> addingPortButton()
             R.id.notify_now -> {
-                val messages = Pair(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW), "The Gitter Channel has been notified.")
+                val messages = Pair(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW), "The Gitter Channel has been notified.")
                 Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
-                writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_NOW))
-            }
+        }
             R.id.btn_add_port -> showDialog(dialog)
             R.id.btn_add_hosts -> showDialog(dialogHosts)
             R.id.btn_keys -> showDialog(dialogKeys)

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -29,7 +29,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
     lateinit var addPortCloseButton: ImageButton
     lateinit var addHostCloseButton: ImageButton
     lateinit var addKeyCloseButton: ImageButton
-    lateinit var nowButton: Button
+    lateinit var notifyButton: Button
 
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -40,7 +40,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         initializeDialog1()
         addPortButton = bind!!.btnAddPort
         addHostButton = bind!!.btnAddHosts
-        nowButton = bind!!.notifyNow
+        notifyButton = bind!!.notifyNow
         arrayOf("1", "2", "three")
         hostsName = ArrayList()
         val adapter: ArrayAdapter<String> = ArrayAdapter(this.requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
@@ -48,7 +48,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addListeners()
         addInfoListener()
         addPortListListener()
-        addNowButtonListener()
+        addNotifyButtonListener()
         return bind!!.root
     }
 
@@ -77,7 +77,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addPortButton!!.setOnClickListener(this); addHostButton!!.setOnClickListener(this)
         addingPortButton.setOnClickListener(this); addingHostButton.setOnClickListener(this)
         addPortCloseButton.setOnClickListener(this); addHostCloseButton.setOnClickListener(this)
-        addKeyCloseButton.setOnClickListener(this); nowButton.setOnClickListener(this)
+        addKeyCloseButton.setOnClickListener(this); notifyButton.setOnClickListener(this)
         bind!!.btnKeys.setOnClickListener(this)
     }
 
@@ -206,7 +206,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, s1, s2))
                 addHostButton!!.text = "Adding......"
                 addHostButton!!.isEnabled = false
-                nowButton!!.isEnabled = true
+                notifyButton!!.isEnabled = true
             } else Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
             dialogHosts.dismiss()
         }
@@ -224,9 +224,9 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         }
     }
 
-    private fun addNowButtonListener() {
+    private fun addNotifyButtonListener() {
         val messages = Pair(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW), "The Gitter Channel has been notified.")
-        nowButton!!.setOnClickListener {
+        notifyButton!!.setOnClickListener {
             Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
         }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -22,12 +22,14 @@ import io.treehouses.remote.bases.BaseTunnelSSHFragment
 import io.treehouses.remote.databinding.ActivityTunnelSshFragmentBinding
 import io.treehouses.remote.utils.DialogUtils
 import io.treehouses.remote.utils.TunnelUtils
+import io.treehouses.remote.utils.Utils
 import io.treehouses.remote.utils.logD
 
 class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
     lateinit var addPortCloseButton: ImageButton
     lateinit var addHostCloseButton: ImageButton
     lateinit var addKeyCloseButton: ImageButton
+    lateinit var nowButton: Button
 
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -38,6 +40,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         initializeDialog1()
         addPortButton = bind!!.btnAddPort
         addHostButton = bind!!.btnAddHosts
+        nowButton = bind!!.notifyNow
         arrayOf("1", "2", "three")
         hostsName = ArrayList()
         val adapter: ArrayAdapter<String> = ArrayAdapter(this.requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
@@ -45,6 +48,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addListeners()
         addInfoListener()
         addPortListListener()
+        addNowButtonListener()
         return bind!!.root
     }
 
@@ -73,7 +77,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         addPortButton!!.setOnClickListener(this); addHostButton!!.setOnClickListener(this)
         addingPortButton.setOnClickListener(this); addingHostButton.setOnClickListener(this)
         addPortCloseButton.setOnClickListener(this); addHostCloseButton.setOnClickListener(this)
-        addKeyCloseButton.setOnClickListener(this); bind!!.notifyNow.setOnClickListener(this)
+        addKeyCloseButton.setOnClickListener(this); nowButton.setOnClickListener(this)
         bind!!.btnKeys.setOnClickListener(this)
     }
 
@@ -202,6 +206,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, s1, s2))
                 addHostButton!!.text = "Adding......"
                 addHostButton!!.isEnabled = false
+                nowButton!!.isEnabled = true
             } else Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
             dialogHosts.dismiss()
         }
@@ -216,6 +221,13 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             addPortButton!!.text = "Adding......"
             addPortButton!!.isEnabled = false
             dialog.dismiss()
+        }
+    }
+
+    private fun addNowButtonListener() {
+        val messages = Pair(getString(R.string.TREEHOUSES_TOR_NOTICE_NOW), "The Gitter Channel has been notified.")
+        nowButton!!.setOnClickListener {
+            Utils.sendMessage(listener, messages, requireContext(), Toast.LENGTH_SHORT)
         }
     }
 
@@ -257,6 +269,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             else if (readMessage.trim().contains("Removed") && lastMessage == getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_ALL)) {
                 portsName!!.clear()
                 adapter?.notifyDataSetChanged()
+                bind!!.notifyNow.isEnabled = false
                 writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE));
             } else if ((modifyKeywords.filter { it in readMessage }).isNotEmpty()) handleModifiedList()
             else if (readMessage.contains("@") && lastMessage == getString(R.string.TREEHOUSES_SSHTUNNEL_PORTS)) handleNewList(readMessage);

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -33,19 +33,15 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityTunnelSshFragmentBinding.inflate(inflater, container, false)
-        bind!!.switchNotification.isEnabled = false
-        bind!!.notifyNow.isEnabled = false
+        bind!!.switchNotification.isEnabled = false; bind!!.notifyNow.isEnabled = false
         portList = bind!!.sshPorts
         initializeDialog1()
-        addPortButton = bind!!.btnAddPort
-        addHostButton = bind!!.btnAddHosts
+        addPortButton = bind!!.btnAddPort; addHostButton = bind!!.btnAddHosts
         arrayOf("1", "2", "three")
         hostsName = ArrayList()
         val adapter: ArrayAdapter<String> = ArrayAdapter(this.requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
         dropdown?.adapter = adapter
-        addListeners()
-        addInfoListener()
-        addPortListListener()
+        addListeners(); addInfoListener(); addPortListListener()
         return bind!!.root
     }
 
@@ -71,11 +67,9 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
 
     private fun addListeners() {
         bind!!.switchNotification.setOnCheckedChangeListener { _, isChecked -> switchButton(isChecked) }
-        addPortButton!!.setOnClickListener(this); addHostButton!!.setOnClickListener(this)
-        addingPortButton.setOnClickListener(this); addingHostButton.setOnClickListener(this)
-        addPortCloseButton.setOnClickListener(this); addHostCloseButton.setOnClickListener(this)
-        addKeyCloseButton.setOnClickListener(this); bind!!.notifyNow.setOnClickListener(this)
-        bind!!.btnKeys.setOnClickListener(this)
+        addPortButton!!.setOnClickListener(this); addHostButton!!.setOnClickListener(this); addingPortButton.setOnClickListener(this)
+        addingHostButton.setOnClickListener(this);addPortCloseButton.setOnClickListener(this); addHostCloseButton.setOnClickListener(this)
+        addKeyCloseButton.setOnClickListener(this); bind!!.notifyNow.setOnClickListener(this); bind!!.btnKeys.setOnClickListener(this)
     }
 
     @RequiresApi(Build.VERSION_CODES.N)

--- a/app/src/main/res/drawable/gitter_button.xml
+++ b/app/src/main/res/drawable/gitter_button.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="false">
-        <shape android:shape="rectangle">
-            <solid android:color="#c02d64"/>
-            <corners android:radius="15dp"/>
-        </shape>
+    <item android:state_enabled="true" android:drawable="@drawable/gitter_button_enabled" >
     </item>
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <solid android:color="@color/md_grey_500"/>
-            <corners android:radius="15dp"/>
-        </shape>
+    <item android:state_enabled="false" android:drawable="@drawable/gitter_button_disabled" >
     </item>
+
 </selector>

--- a/app/src/main/res/drawable/gitter_button_disabled.xml
+++ b/app/src/main/res/drawable/gitter_button_disabled.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="false">
+        <shape android:shape="rectangle">
+            <solid android:color="#4C4849"/>
+            <corners android:radius="15dp"/>
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/md_grey_500"/>
+            <corners android:radius="15dp"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/gitter_button_enabled.xml
+++ b/app/src/main/res/drawable/gitter_button_enabled.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="false">
+        <shape android:shape="rectangle">
+            <solid android:color="#c02d64"/>
+            <corners android:radius="15dp"/>
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/md_grey_500"/>
+            <corners android:radius="15dp"/>
+        </shape>
+    </item>
+</selector>


### PR DESCRIPTION
fixes #1738 

### Description
Made it so that the gitter notify button is disabled when there's no host. Once a host gets added, gitter notify gets re-enabled
![Screenshot_20210209-020429_Treehouses Remote](https://user-images.githubusercontent.com/46581520/107327665-7a481c80-6a7b-11eb-9345-29fa9a64facc.jpg)
![Screenshot_20210209-020455_Treehouses Remote](https://user-images.githubusercontent.com/46581520/107327673-7d430d00-6a7b-11eb-9239-667e68cf0256.jpg)

