### PR TITLE
sshtunnel: host syntax check added (fixes #1742 )

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/Constants.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/Constants.kt
@@ -65,4 +65,15 @@ object Constants {
 
     //JSON String bundle
     const val JSON_STRING = "jsonString"
+
+    //Regular Expressions
+    const val userRegex = "^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\\\$)\$"
+    const val domainRegex = "^(?!-)[A-Za-z0-9-]+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,}\$"
+    const val ipRegex = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\$"
+    const val portRegex = "(?:[0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])"
+
+    //Error messages
+    const val hostError = "Invalid host name"
+    const val domainIPError = "Invalid Domain or IP"
+    const val portError = "Invalid port name"
 }

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -31,8 +31,9 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected var hostsPosition: java.util.ArrayList<Int>? = null
     protected lateinit var dialogHosts: Dialog
     protected lateinit var dialogKeys: Dialog
-    protected lateinit var inputExternalHost: TextInputEditText
-    protected lateinit var inputInternalHost: TextInputEditText
+    protected lateinit var inputUserName: TextInputEditText
+    protected lateinit var inputDomainIP: TextInputEditText
+    protected lateinit var inputPortNumber: TextInputEditText
     protected lateinit var inputExternal: TextInputEditText
     protected lateinit var inputInternal: TextInputEditText
     protected lateinit var dialog: Dialog

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -33,6 +33,7 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected lateinit var dialogHosts: Dialog
     protected lateinit var dialogKeys: Dialog
     protected lateinit var textLayoutUserName: TextInputLayout
+    protected lateinit var textLayoutDomainName: TextInputLayout
     protected lateinit var textLayoutPortName: TextInputLayout
     protected lateinit var inputUserName: TextInputEditText
     protected lateinit var inputDomainIP: TextInputEditText

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -16,7 +16,6 @@ import io.treehouses.remote.utils.RESULTS
 import io.treehouses.remote.utils.Utils
 import io.treehouses.remote.utils.logD
 import io.treehouses.remote.utils.match
-import kotlinx.android.synthetic.main.activity_tunnel_ssh_fragment.*
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -257,31 +256,6 @@ open class BaseTunnelSSHFragment : BaseFragment() {
         writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_PORTS))
     }
 
-    protected fun handleNewList(readMessage: String) {
-        var position = 0
-        addPortButton?.isEnabled = true
-        addPortButton?.text = "Add Port"; addHostButton?.text = "Add Host"
-        addPortButton!!.isEnabled = true; addHostButton?.isEnabled = true
-        bind!!.notifyNow.isEnabled = true
-        val hosts = readMessage.split('\n')
-        for (host in hosts) {
-            val ports = host.split(' ')
-            for (port in ports) {
-                if (port.length >= 3) portsName!!.add(port)
-                if (port.contains("@")) {
-                    hostsPosition!!.add(position)
-                    hostsName!!.add(port)
-                }
-                position += 1
-            }
-        }
 
-        if(portsName!!.size > 1) portsName!!.add("All")
-        adapter2 = ArrayAdapter(requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
-        dropdown?.adapter = adapter2
-        adapter = TunnelPortAdapter(requireContext(), portsName!!)
-          bind!!.sshPorts.adapter = adapter
-        portList!!.isEnabled = true
-    }
 
 }

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTunnelSSHFragment.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.view.View
 import android.widget.*
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import io.treehouses.remote.R
 import io.treehouses.remote.adapter.TunnelPortAdapter
 import io.treehouses.remote.databinding.ActivityTunnelSshFragmentBinding
@@ -31,6 +32,8 @@ open class BaseTunnelSSHFragment : BaseFragment() {
     protected var hostsPosition: java.util.ArrayList<Int>? = null
     protected lateinit var dialogHosts: Dialog
     protected lateinit var dialogKeys: Dialog
+    protected lateinit var textLayoutUserName: TextInputLayout
+    protected lateinit var textLayoutPortName: TextInputLayout
     protected lateinit var inputUserName: TextInputEditText
     protected lateinit var inputDomainIP: TextInputEditText
     protected lateinit var inputPortNumber: TextInputEditText

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -10,7 +10,6 @@ import android.os.Message
 import android.text.Editable
 import android.text.Html
 import android.text.Spanned
-import android.text.TextWatcher
 import android.view.*
 import android.widget.*
 import androidx.annotation.RequiresApi
@@ -27,6 +26,7 @@ class TunnelSSHFragment : TunnelSSHFunctions(), View.OnClickListener {
     lateinit var addPortCloseButton: ImageButton
     lateinit var addHostCloseButton: ImageButton
     lateinit var addKeyCloseButton: ImageButton
+
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityTunnelSshFragmentBinding.inflate(inflater, container, false)
@@ -73,43 +73,19 @@ class TunnelSSHFragment : TunnelSSHFunctions(), View.OnClickListener {
         dialogKeys.setContentView(R.layout.dialog_sshtunnel_key); dropdown = dialog.findViewById(R.id.hosts)
         inputExternal = dialog.findViewById(R.id.ExternalTextInput); inputInternal = dialog.findViewById(R.id.InternalTextInput)
         textLayoutUserName = dialogHosts.findViewById(R.id.TLusername); textLayoutPortName = dialogHosts.findViewById(R.id.TLportname)
-        inputUserName = dialogHosts.findViewById(R.id.UserNameInput); inputDomainIP = dialogHosts.findViewById(R.id.DomainIPInput); inputPortNumber = dialogHosts.findViewById(R.id.PortNumberInput)
+        textLayoutDomainName = dialogHosts.findViewById(R.id.TLdomain); inputUserName = dialogHosts.findViewById(R.id.UserNameInput)
+        inputDomainIP = dialogHosts.findViewById(R.id.DomainIPInput); inputPortNumber = dialogHosts.findViewById(R.id.PortNumberInput)
         addingPortButton = dialog.findViewById(R.id.btn_adding_port); addingHostButton = dialogHosts.findViewById(R.id.btn_adding_host)
         addCloseButtons()
-        inputUserName.addTextChangedListener(object :TextWatcher{
-            override fun afterTextChanged(s: Editable?) {
-                if(s!!.isEmpty()){
-                    addingHostButton.isEnabled = false
-                } else {
-                    if (!s.toString().matches("^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\\\$)\$".toRegex())) {
-                        addingHostButton.isEnabled = false
-                        Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
-                        textLayoutUserName.setError("Invalid User Name")
-                    } else addingHostButton.isEnabled = true
-                }
-            }
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-        })
-        inputPortNumber.addTextChangedListener(object :TextWatcher{
-            override fun afterTextChanged(s: Editable?) {
-                if(s!!.isEmpty()){
-                    addingHostButton.isEnabled = false
-                } else {
-                    if(try {s!!.toString().toInt() > 65535 } catch(e: NumberFormatException){ true }){
-                        addingHostButton.isEnabled = false
-                        Toast.makeText(requireContext(), "Invalid port number", Toast.LENGTH_SHORT).show()
-                        textLayoutPortName.setError("Invalid port number")
-                    } else addingHostButton.isEnabled = true
-                }
-            }
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-        })
+        addSyntaxCheck(inputUserName, textLayoutUserName, Constants.userRegex, Constants.hostError)
+        addSyntaxCheck(inputDomainIP, textLayoutDomainName, Constants.domainRegex + "|" + Constants.ipRegex , Constants.domainIPError)
+        addSyntaxCheck(inputPortNumber, textLayoutPortName, Constants.portRegex, Constants.portError)
         portsName = ArrayList(); hostsName = ArrayList(); hostsPosition = ArrayList()
         val window = dialog.window; val windowHost = dialogHosts.window
-        window!!.setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT); windowHost!!.setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE); windowHost.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        window!!.setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        windowHost!!.setLayout(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        windowHost.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
         try { initializeDialog2() }
         catch (exception: Exception) { }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -78,7 +78,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
         dialog.setContentView(R.layout.dialog_sshtunnel_ports); dialogHosts.setContentView(R.layout.dialog_sshtunnel_hosts)
         dialogKeys.setContentView(R.layout.dialog_sshtunnel_key); dropdown = dialog.findViewById(R.id.hosts)
         inputExternal = dialog.findViewById(R.id.ExternalTextInput); inputInternal = dialog.findViewById(R.id.InternalTextInput)
-        inputExternalHost = dialogHosts.findViewById(R.id.ExternalTextInput); inputInternalHost = dialogHosts.findViewById(R.id.InternalTextInput)
+        inputUserName = dialogHosts.findViewById(R.id.UserNameInput); inputDomainIP = dialogHosts.findViewById(R.id.DomainIPInput); inputPortNumber = dialogHosts.findViewById(R.id.PortNumberInput)
         addingPortButton = dialog.findViewById(R.id.btn_adding_port); addingHostButton = dialogHosts.findViewById(R.id.btn_adding_host)
         addCloseButtons()
         portsName = ArrayList(); hostsName = ArrayList(); hostsPosition = ArrayList()
@@ -190,14 +190,17 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
     }
 
     private fun addingHostButton() {
-        val s1 = inputInternalHost.text.toString(); val s2 = inputExternalHost.text.toString()
-        if (s1.isNotEmpty() && s2.isNotEmpty()) {
-            if (!s2.contains("@")) {
+        val s1 = inputPortNumber; val s2 = inputUserName; val s3 = inputDomainIP
+        if (s1.text.toString().isNotEmpty() && s2.text.toString().isNotEmpty() && s3.text.toString().isNotEmpty()) {
+            if (!s2.text.toString().matches("^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\\\$)\$".toRegex())) {
                 Toast.makeText(requireContext(), "Invalid host name", Toast.LENGTH_SHORT).show()
-            } else if(try {s1.toInt() > 65535 } catch(e: NumberFormatException){ true }){
+                s2.setError("Invalid User Name")
+            } else if(try {s1.text.toString().toInt() > 65535 } catch(e: NumberFormatException){ true }){
                 Toast.makeText(requireContext(), "Invalid port number", Toast.LENGTH_SHORT).show()
             } else {
-                writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, s1, s2))
+                val m1 = s1.text.toString()
+                val m2 = s2.text.toString() + "@" + s3.text.toString()
+                writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, m1, m2))
                 addHostButton!!.text = "Adding......"
                 addHostButton!!.isEnabled = false
             }

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
@@ -1,13 +1,51 @@
 package io.treehouses.remote.fragments
 
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import android.widget.AdapterView
-import android.widget.Toast
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import io.treehouses.remote.R
 import io.treehouses.remote.bases.BaseTunnelSSHFragment
 import io.treehouses.remote.utils.DialogUtils
 
 open class TunnelSSHFunctions: BaseTunnelSSHFragment() {
+
+    /*
+       checks if the inputs in the host dialog are not empty. If so, check if their corresponding textLayouts don't have errors.
+       If so, then enable addingHostButton.
+         */
+    protected fun checkAddingHostButtonEnable(){
+        if(inputUserName.editableText.isNotEmpty() && inputDomainIP.editableText.isNotEmpty() && inputPortNumber.editableText.isNotEmpty())
+            if(!textLayoutUserName.isErrorEnabled && !textLayoutDomainName.isErrorEnabled && !textLayoutPortName.isErrorEnabled )
+                addingHostButton.isEnabled = true
+    }
+
+    /*
+       adds a syntax check to textInputEditText. If input in textInputEditText does not match regex, outputs error message in textInputLayout
+       and disables addingHostButton
+         */
+    protected fun addSyntaxCheck(textInputEditText: TextInputEditText, textInputLayout: TextInputLayout, regex: String, error: String){
+        textInputEditText.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {
+                textInputLayout.setErrorEnabled(true)
+                if(s!!.isEmpty()){
+                    addingHostButton.isEnabled = false
+                } else {
+                    if(!s!!.toString().matches(regex.toRegex()) ){
+                        addingHostButton.isEnabled = false
+                        textInputLayout.setError(error)
+                    } else {
+                        textInputLayout.setErrorEnabled(false)
+                        checkAddingHostButtonEnable()
+                    }
+                }
+            }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        })
+    }
 
     protected fun addPortListListener() {
         portList!!.onItemClickListener = AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->
@@ -24,14 +62,13 @@ open class TunnelSSHFunctions: BaseTunnelSSHFragment() {
     }
 
     protected fun addingHostButton() {
-        if (inputPortNumber.text.toString().isNotEmpty() && inputUserName.text.toString().isNotEmpty() && inputDomainIP.text.toString().isNotEmpty()) {
-            val m1 = inputPortNumber.text.toString()
-            val m2 = inputUserName.text.toString() + "@" + inputDomainIP.text.toString()
-            writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, m1, m2))
-            addHostButton!!.text = "Adding......"
-            addHostButton!!.isEnabled = false
-            dialogHosts.dismiss()
-        }
+        val m1 = inputPortNumber.text.toString()
+        val m2 = inputUserName.text.toString() + "@" + inputDomainIP.text.toString()
+        writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, m1, m2))
+        addHostButton!!.text = "Adding......"
+        addHostButton!!.isEnabled = false
+        dialogHosts.dismiss()
+
     }
 
     protected fun addingPortButton() {

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
@@ -1,0 +1,50 @@
+package io.treehouses.remote.fragments
+
+import android.view.View
+import android.widget.AdapterView
+import android.widget.Toast
+import io.treehouses.remote.R
+import io.treehouses.remote.bases.BaseTunnelSSHFragment
+import io.treehouses.remote.utils.DialogUtils
+
+open class TunnelSSHFunctions: BaseTunnelSSHFragment() {
+
+    protected fun addPortListListener() {
+        portList!!.onItemClickListener = AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, position: Int, _: Long ->
+            if (portsName!!.size > 1 && position == portsName!!.size - 1) {
+                DialogUtils.createAlertDialog(context, "Delete All Hosts and Ports?") { writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_ALL)) }
+            }
+        }
+    }
+
+    protected fun switchButton(isChecked: Boolean) {
+        bind!!.switchNotification.isEnabled = false
+        if (isChecked) writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_ON))
+        else writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_NOTICE_OFF))
+    }
+
+    protected fun addingHostButton() {
+        if (inputPortNumber.text.toString().isNotEmpty() && inputUserName.text.toString().isNotEmpty() && inputDomainIP.text.toString().isNotEmpty()) {
+            val m1 = inputPortNumber.text.toString()
+            val m2 = inputUserName.text.toString() + "@" + inputDomainIP.text.toString()
+            writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_HOST, m1, m2))
+            addHostButton!!.text = "Adding......"
+            addHostButton!!.isEnabled = false
+            dialogHosts.dismiss()
+        }
+    }
+
+    protected fun addingPortButton() {
+        if (inputExternal.text!!.isNotEmpty() && inputInternal.text!!.isNotEmpty()) {
+            val s1 = inputInternal.text.toString()
+            val s2 = inputExternal.text.toString()
+            val parts = dropdown?.selectedItem.toString().split(":")[0]
+            writeMessage(getString(R.string.TREEHOUSES_SSHTUNNEL_ADD_PORT_ACTUAL, s2, s1, parts))
+            addPortButton!!.text = "Adding......"
+            addPortButton!!.isEnabled = false
+            dialog.dismiss()
+        }
+    }
+
+
+}

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFunctions.kt
@@ -4,9 +4,11 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
 import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import io.treehouses.remote.R
+import io.treehouses.remote.adapter.TunnelPortAdapter
 import io.treehouses.remote.bases.BaseTunnelSSHFragment
 import io.treehouses.remote.utils.DialogUtils
 
@@ -81,6 +83,33 @@ open class TunnelSSHFunctions: BaseTunnelSSHFragment() {
             addPortButton!!.isEnabled = false
             dialog.dismiss()
         }
+    }
+
+    protected fun handleNewList(readMessage: String) {
+        var position = 0
+        addPortButton?.isEnabled = true
+        addPortButton?.text = "Add Port"; addHostButton?.text = "Add Host"
+        addPortButton!!.isEnabled = true; addHostButton?.isEnabled = true
+        bind!!.notifyNow.isEnabled = true
+        val hosts = readMessage.split('\n')
+        for (host in hosts) {
+            val ports = host.split(' ')
+            for (port in ports) {
+                if (port.length >= 3) portsName!!.add(port)
+                if (port.contains("@")) {
+                    hostsPosition!!.add(position)
+                    hostsName!!.add(port)
+                }
+                position += 1
+            }
+        }
+
+        if(portsName!!.size > 1) portsName!!.add("All")
+        adapter2 = ArrayAdapter(requireContext(), R.layout.support_simple_spinner_dropdown_item, hostsName!!)
+        dropdown?.adapter = adapter2
+        adapter = TunnelPortAdapter(requireContext(), portsName!!)
+        bind!!.sshPorts.adapter = adapter
+        portList!!.isEnabled = true
     }
 
 

--- a/app/src/main/res/drawable/addhost_button.xml
+++ b/app/src/main/res/drawable/addhost_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:drawable="@drawable/ic_green" >
+    </item>
+    <item android:state_enabled="false" android:drawable="@drawable/ic_grey_dark" >
+    </item>
+</selector>

--- a/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
@@ -112,7 +112,8 @@
                 android:hint="Port Number"
                 android:inputType="number"
                 android:textColor="@color/daynight_textColor"
-                android:textColorHint="@color/expandable_child_text" />
+                android:textColorHint="@color/expandable_child_text"
+                android:maxLength="5"/>
 
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
@@ -124,6 +125,7 @@
         android:layout_marginTop="@dimen/margin_small"
         android:text="Add host"
         android:background="@drawable/addhost_button"
+        android:enabled="false"
         android:textColor="#FFFFFF"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
@@ -44,29 +44,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
-
-
-
-            android:spinnerMode="dropdown"/>
-    </LinearLayout>
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/UserNameInput"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:fontFamily="sans-serif"
-            android:textColorHint="@color/expandable_child_text"
-            android:textColor="@color/daynight_textColor"
-            android:hint="User Name"
-            />
-
     </LinearLayout>
 
     <LinearLayout
@@ -75,34 +52,70 @@
         android:orientation="horizontal">
 
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/DomainIPInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:fontFamily="sans-serif"
-            android:hint="Domain Name or IP"
-            android:textColor="@color/daynight_textColor"
-            android:textColorHint="@color/expandable_child_text" />
-
-    </LinearLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textColorHint="@color/expandable_child_text"
-        >
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/PortNumberInput"
+        <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fontFamily="sans-serif"
-            android:hint="Port Number"
-            android:inputType="number"
-            android:textColor="@color/daynight_textColor" />
+            android:id="@+id/TLusername"
+            >
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/UserNameInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:textColorHint="@color/expandable_child_text"
+                android:textColor="@color/daynight_textColor"
+                android:hint="User Name" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/TLdomain"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/DomainIPInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:hint="Domain Name or IP"
+                android:textColor="@color/daynight_textColor"
+                android:textColorHint="@color/expandable_child_text" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/TLportname"
+            >
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/PortNumberInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:hint="Port Number"
+                android:inputType="number"
+                android:textColor="@color/daynight_textColor"
+                android:textColorHint="@color/expandable_child_text" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
 
     <Button
         android:id="@+id/btn_adding_host"
@@ -110,7 +123,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
         android:text="Add host"
-        android:background="@drawable/ic_green"
+        android:background="@drawable/addhost_button"
         android:textColor="#FFFFFF"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
+++ b/app/src/main/res/layout/dialog_sshtunnel_hosts.xml
@@ -57,15 +57,33 @@
 
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/ExternalTextInput"
+            android:id="@+id/UserNameInput"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif"
             android:textColorHint="@color/expandable_child_text"
             android:textColor="@color/daynight_textColor"
-            android:hint="Host Name"
+            android:hint="User Name"
             />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/DomainIPInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="sans-serif"
+            android:hint="Domain Name or IP"
+            android:textColor="@color/daynight_textColor"
+            android:textColorHint="@color/expandable_child_text" />
 
     </LinearLayout>
 
@@ -76,14 +94,13 @@
         >
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/InternalTextInput"
+            android:id="@+id/PortNumberInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/daynight_textColor"
             android:fontFamily="sans-serif"
             android:hint="Port Number"
             android:inputType="number"
-            />
+            android:textColor="@color/daynight_textColor" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,7 +307,8 @@
         <b>Adding SSH Hosts</b>
         "\n"To add an SSH host, one must click on the Add Hosts button.
         "\n"This is a reverse SSH tunnel in which another port is being opened to this.
-        "\n"For the name, it will follow the format of ole@tunnel.ole.org.
+        "\n"For the user name, it will be a regular Linux username.
+        "\n"For the domain name, it needs to be a valid domain or IP address.
         <b>Adding SSH Ports</b>
         "\n"To add an SSH port, one must click on the Add Ports button.
         "\n"Add the external and internal number of the port"\n"


### PR DESCRIPTION
fixes #1742 

### Description
massively update the add host dialog
updates are:

- split host name input into two text inputs, one for the username and another for the domain name. updated info text to reflect this change
- add syntax checks for all inputs, add host button is only enabled if all inputs are filled and don't have errors
- reduced number of code lines in TunnelSSHFragment and BaseTunnelSSHFragment by moving some functions into a new file called TunnelSSHFunctions