### PR TITLE
sshtunnel: defining host enables add port button (fixes #1755)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TunnelSSHFragment.kt
@@ -253,6 +253,7 @@ class TunnelSSHFragment : BaseTunnelSSHFragment(), View.OnClickListener {
             if (lastMessage == getString(R.string.TREEHOUSES_REMOTE_KEY_SEND)) logD("Key send: $readMessage")
             val modifyKeywords = arrayOf("Added", "Removed")
             if (readMessage.contains("Host / port not found")) handleHostNotFound()
+            else if (readMessage.trim().contains("no tunnel has been set up")) addPortButton?.isEnabled = false
             else if (readMessage.trim().contains("Removed") && lastMessage == getString(R.string.TREEHOUSES_SSHTUNNEL_REMOVE_ALL)) {
                 portsName!!.clear()
                 adapter?.notifyDataSetChanged()

--- a/app/src/main/res/drawable/addport_button.xml
+++ b/app/src/main/res/drawable/addport_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:drawable="@drawable/ic_green" >
+    </item>
+    <item android:state_enabled="false" android:drawable="@drawable/ic_grey_dark" >
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_tunnel_ssh_fragment.xml
+++ b/app/src/main/res/layout/activity_tunnel_ssh_fragment.xml
@@ -111,7 +111,7 @@
             android:layout_marginTop="20dp"
             android:textColor="@color/bg_white"
             android:textAppearance="@style/TextAppearance.AppCompat.Small"
-            android:background="@drawable/ic_green"
+            android:background="@drawable/addport_button"
             android:text="Add Port"
             android:layout_weight="1"/>
 


### PR DESCRIPTION
fixes #1755 

### Description

When there's no host, the add port button is disabled
![Screenshot (796)](https://user-images.githubusercontent.com/46581520/109554962-f3e39100-7aa2-11eb-811f-40226be10956.png)
![Screenshot (797)](https://user-images.githubusercontent.com/46581520/109554966-f47c2780-7aa2-11eb-90b8-2afb1f6d6955.png)

