### PR TITLE
ssh: avoid crashes (fixes #1771)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHConfig.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHConfig.kt
@@ -46,6 +46,7 @@ open class BaseSSHConfig: BaseFragment(), RVButtonClickListener, OnHostStatusCha
 
     protected fun setUpAdapter() {
         pastHosts = SaveUtils.getAllHosts(requireContext()).reversed()
+        if (!isVisible) return
         if (pastHosts.isEmpty()) {
             bind.noHosts.visibility = View.VISIBLE
             bind.pastHosts.visibility = View.GONE
@@ -82,6 +83,11 @@ open class BaseSSHConfig: BaseFragment(), RVButtonClickListener, OnHostStatusCha
     override fun onAttach(context: Context) {
         super.onAttach(context)
         activity?.bindService(Intent(context, TerminalManager::class.java), connection, Context.BIND_AUTO_CREATE)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        try {activity?.unbindService(connection)} catch (e: Exception) {logD("SSHConfig $e")}
     }
 
     override fun onStop() {

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHConfig.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHConfig.kt
@@ -85,11 +85,6 @@ open class BaseSSHConfig: BaseFragment(), RVButtonClickListener, OnHostStatusCha
         activity?.bindService(Intent(context, TerminalManager::class.java), connection, Context.BIND_AUTO_CREATE)
     }
 
-    override fun onDetach() {
-        super.onDetach()
-        try {activity?.unbindService(connection)} catch (e: Exception) {logD("SSHConfig $e")}
-    }
-
     override fun onStop() {
         super.onStop()
         try {activity?.unbindService(connection)} catch (e: Exception) {logD("SSHConfig $e")}


### PR DESCRIPTION
fixes #1771 

### Description
Resolve SSH page crashing when switching from light mode to dark mode and vice versa