### PR TITLE
main: ready menu for variable font sizes (fixes #1762)

### DIFF
--- a/app/src/main/res/layout/navigation_view_header.xml
+++ b/app/src/main/res/layout/navigation_view_header.xml
@@ -56,7 +56,7 @@
 
     <TextView
         android:layout_width="wrap_content"
-        android:layout_height="23dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginTop="8dp"


### PR DESCRIPTION
fixes #1762 

### Description

change the height property of the remote TextView box to "wrap content" rather than a fixed size. This causes the symbol, which was a view scroller, to not appear on larger font sizes