### PR TITLE
terminal: no crash (fixes #1780)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TerminalFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TerminalFragment.kt
@@ -91,13 +91,13 @@ class TerminalFragment : BaseTerminalFragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if(chatOpen()) {
             if (mChatService.state == Constants.STATE_NONE) {
                 mChatService.start()
                 updatePingStatus(bind.pingStatus, bind.PING, getString(R.string.bStatusIdle), Color.YELLOW)
             }
         }
+        super.onDestroy()
     }
 
     override fun onResume() {


### PR DESCRIPTION
fixes #1780 

### Description

resolve potential crashing with terminal fragment by putitng onDestroy's super function in front