### PR TITLE
home: check for progress dialog (fixes #1538)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
@@ -34,7 +34,6 @@ import io.treehouses.remote.pojo.enum.Status
 import io.treehouses.remote.utils.SaveUtils
 import io.treehouses.remote.utils.Utils
 import io.treehouses.remote.utils.Utils.toast
-import io.treehouses.remote.utils.logD
 import io.treehouses.remote.utils.logE
 
 class HomeFragment : BaseHomeFragment() {
@@ -158,7 +157,6 @@ class HomeFragment : BaseHomeFragment() {
         bind.networkProfiles.setAdapter(profileAdapter)
         bind.networkProfiles.setOnChildClickListener { _: ExpandableListView?, _: View?, groupPosition: Int, childPosition: Int, _: Long ->
             if (groupPosition == 3) {
-                logD("Test default")
                 viewModel.sendMessage(getString(R.string.TREEHOUSES_DEFAULT_NETWORK))
                 context.toast("Switched to Default Network", Toast.LENGTH_LONG)
             } else if (SaveUtils.getProfiles(requireContext()).size > 0 && SaveUtils.getProfiles(requireContext())[listOf(*group_labels)[groupPosition]]!!.isNotEmpty()) {

--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeFragment.kt
@@ -34,6 +34,7 @@ import io.treehouses.remote.pojo.enum.Status
 import io.treehouses.remote.utils.SaveUtils
 import io.treehouses.remote.utils.Utils
 import io.treehouses.remote.utils.Utils.toast
+import io.treehouses.remote.utils.logD
 import io.treehouses.remote.utils.logE
 
 class HomeFragment : BaseHomeFragment() {
@@ -132,7 +133,7 @@ class HomeFragment : BaseHomeFragment() {
                     if (it.message.isNotEmpty()) context.toast(it.message)
                 }
                 Status.LOADING -> {
-                    if (it == null) return@Observer
+                    if (it == null || it.data?.ssid == null) return@Observer
                     progressDialog = ProgressDialog.show(ContextThemeWrapper(context, R.style.CustomAlertDialogStyle), "Connecting...", "Switching to " + it.data?.ssid, true)
                     progressDialog?.window!!.setBackgroundDrawableResource(android.R.color.transparent)
                     progressDialog?.show()
@@ -157,6 +158,7 @@ class HomeFragment : BaseHomeFragment() {
         bind.networkProfiles.setAdapter(profileAdapter)
         bind.networkProfiles.setOnChildClickListener { _: ExpandableListView?, _: View?, groupPosition: Int, childPosition: Int, _: Long ->
             if (groupPosition == 3) {
+                logD("Test default")
                 viewModel.sendMessage(getString(R.string.TREEHOUSES_DEFAULT_NETWORK))
                 context.toast("Switched to Default Network", Toast.LENGTH_LONG)
             } else if (SaveUtils.getProfiles(requireContext()).size > 0 && SaveUtils.getProfiles(requireContext())[listOf(*group_labels)[groupPosition]]!!.isNotEmpty()) {


### PR DESCRIPTION
fixes #1538

### Description

added an additional check for ProgressDialog so that it doesn't appear when data is null