### PR TITLE
about: introduce discord (fixes #1816)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/AboutFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/AboutFragment.kt
@@ -33,12 +33,12 @@ class AboutFragment : Fragment() {
     private fun setHyperlinks(view: View) {
         val gitHub = view.findViewById<Button>(R.id.btn_github)
         val images = view.findViewById<Button>(R.id.btn_image)
-        val gitter = view.findViewById<Button>(R.id.btn_gitter)
+        val discord = view.findViewById<Button>(R.id.btn_discord)
         val contributors = view.findViewById<Button>(R.id.btn_contributors)
 
         hyperLinks(gitHub, "https://github.com/treehouses/remote")
         hyperLinks(images, "https://treehouses.io/#!pages/download.md")
-        hyperLinks(gitter, "https://gitter.im/open-learning-exchange/raspberrypi")
+        hyperLinks(discord, "https://discord.gg/mtgGD4EnYW")
         hyperLinks(contributors, "https://github.com/treehouses/remote/graphs/contributors")
 
     }

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -45,11 +45,11 @@
             android:text="Treehouses Image"
             android:textColor="@color/bg_white"
             app:layout_constraintBottom_toTopOf="@+id/btn_version"
-            app:layout_constraintEnd_toStartOf="@+id/btn_gitter"
+            app:layout_constraintEnd_toStartOf="@+id/btn_discord"
             app:layout_constraintStart_toEndOf="@+id/btn_github" />
 
         <Button
-            android:id="@+id/btn_gitter"
+            android:id="@+id/btn_discord"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
@@ -57,7 +57,7 @@
             android:layout_marginBottom="16dp"
             android:background="@drawable/ic_about_btn"
             android:gravity="center"
-            android:text="gitter"
+            android:text="discord"
             android:textColor="@color/bg_white"
             android:textSize="@dimen/text_size_small"
             app:layout_constraintBottom_toTopOf="@+id/btn_version"


### PR DESCRIPTION
switched gitter button in about page with discord button
![Screenshot (1271)](https://user-images.githubusercontent.com/46581520/222875996-88f4e386-fefb-4435-a8c2-48861ba81be1.png)
