### PR TITLE
actions: bluetooth permission newer way (fixes #1832)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <!-- Min/target SDK versions (<uses-sdk>) managed by build.gradle -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
@@ -2,6 +2,7 @@ package io.treehouses.remote.bases
 
 import android.app.Notification
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.Service
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -54,9 +55,7 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
     }
 
     open fun start() {}
-
-
-
+    
     /**
      * Update UI title according to the current state of the chat connection
      */
@@ -82,10 +81,10 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
 
     protected fun startNotification() {
         val disconnectIntent = Intent(DISCONNECT_ACTION)
-        val disconnectPendingIntent: PendingIntent = PendingIntent.getBroadcast(this, 0, disconnectIntent, 0)
+        val disconnectPendingIntent: PendingIntent = PendingIntent.getBroadcast(this, 0, disconnectIntent, FLAG_IMMUTABLE)
 
         val onClickIntent = Intent(this, InitialActivity::class.java)
-        val pendingClickIntent = PendingIntent.getActivity(this, 0, onClickIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+        val pendingClickIntent = PendingIntent.getActivity(this, 0, onClickIntent, FLAG_IMMUTABLE)
 
         val notificationBuilder: NotificationCompat.Builder = NotificationCompat.Builder(this, getString(R.string.bt_notification_ID))
         val notification: Notification = notificationBuilder.setOngoing(true)

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
@@ -55,7 +55,7 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
     }
 
     open fun start() {}
-    
+
     /**
      * Update UI title according to the current state of the chat connection
      */

--- a/app/src/main/kotlin/io/treehouses/remote/bases/PermissionActivity.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/PermissionActivity.kt
@@ -39,11 +39,21 @@ abstract class PermissionActivity : AppCompatActivity() {
     }
 
     fun requestPermission() {
-        if (!checkPermission(Manifest.permission.ACCESS_FINE_LOCATION) || !checkPermission(Manifest.permission.ACCESS_COARSE_LOCATION) || !checkPermission(Manifest.permission.CHANGE_WIFI_STATE)) {
+        if (!checkPermission(Manifest.permission.ACCESS_FINE_LOCATION) ||
+            !checkPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ||
+            !checkPermission(Manifest.permission.CHANGE_WIFI_STATE) ||
+            !checkPermission(Manifest.permission.BLUETOOTH) ||
+            !checkPermission(Manifest.permission.BLUETOOTH_ADMIN) ||
+            !checkPermission(Manifest.permission.BLUETOOTH_CONNECT) ||
+            !checkPermission(Manifest.permission.BLUETOOTH_CONNECT)) {
             ActivityCompat.requestPermissions(this, arrayOf(
-                    Manifest.permission.CHANGE_WIFI_STATE,
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.ACCESS_COARSE_LOCATION
+                Manifest.permission.CHANGE_WIFI_STATE,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.BLUETOOTH,
+                Manifest.permission.BLUETOOTH_ADMIN,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_SCAN,
             ), PERMISSION_REQUEST_WIFI)
         } else {
             statusCheck()


### PR DESCRIPTION
fixes #1832
this pr adds 

- `android.permission.BLUETOOTH_CONNECT`- needed to connect with already-paired Bluetooth devices
- `android.permission.BLUETOOTH_SCAN` : needed to scan for bluetooth devices 

![image](https://github.com/treehouses/remote/assets/64019708/36de8ced-7226-4236-be44-47c83f96809f)
