### PR TITLE
settings: default terminal `autocomplete` to false (fixes #1834)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/TerminalFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/TerminalFragment.kt
@@ -47,7 +47,7 @@ class TerminalFragment : BaseTerminalFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         bind = ActivityTerminalFragmentBinding.inflate(inflater, container, false)
         onLoad(mHandler)
-        val autocomplete = PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean("autocomplete", true)
+        val autocomplete = PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean("autocomplete", false)
         if (autocomplete) {
             jsonSend(true)
             listener.sendMessage(getString(R.string.TREEHOUSES_COMMANDS_JSON))

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -14,7 +14,7 @@
             android:layout="@layout/custom_pref_middle"
             android:summary="Enable or Disable Autocomplete Suggestions of Commands in Terminal"
             android:key="autocomplete"
-            android:defaultValue="true" />
+            android:defaultValue="false" />
 
         <io.treehouses.remote.views.RoundedListPreference
             android:defaultValue="Follow System"


### PR DESCRIPTION
fixes #1834
this pr ensures default autocomplete is set to false 
![Screenshot 2024-02-06 13 29 20](https://github.com/treehouses/remote/assets/64019708/8a827812-f6aa-47ec-a0b7-9ebdc18df500)
