### PR TITLE
actions: use `BluetoothManager` (fixes #1860)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.Service
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -21,22 +22,17 @@ import java.io.Serializable
 import java.util.*
 
 open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? = null, applicationContext: Context? = null) : Service(), Serializable {
-
     var mDevice: BluetoothDevice? = null
-    var context: Context?
+    var context: Context? = null
     var mNewState: Int
     var bNoReconnect = false
+    var state: Int
     //    private AcceptThread mSecureAcceptThread;
     //private AcceptThread mInsecureAcceptThread;
 
-    /**
-     * Return the current connection state.
-     */
-    @get:Synchronized
-    var state: Int
-        set
-
-    val mAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+    val mAdapter: BluetoothAdapter? by lazy {
+        (applicationContext?.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+    }
 
     /**
      * Indicate that the connection attempt failed and notify the UI Activity.
@@ -109,7 +105,7 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
         state = Constants.STATE_NONE
         mNewState = state
         mHandler = handler
-        context = applicationContext
+        this.context = applicationContext
     }
 
     companion object {

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseBluetoothChatService.kt
@@ -27,8 +27,6 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
     var mNewState: Int
     var bNoReconnect = false
     var state: Int
-    //    private AcceptThread mSecureAcceptThread;
-    //private AcceptThread mInsecureAcceptThread;
 
     val mAdapter: BluetoothAdapter? by lazy {
         (applicationContext?.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
@@ -109,15 +107,9 @@ open class BaseBluetoothChatService @JvmOverloads constructor(handler: Handler? 
     }
 
     companion object {
-        // Debugging
         const val TAG = "BluetoothChatService"
         const val DISCONNECT_ACTION = "disconnect"
-        //private static final String NAME_INSECURE = "BluetoothChatInsecure";
-        // well-known SPP UUID 00001101-0000-1000-8000-00805F9B34FB
         val MY_UUID_SECURE = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
         var mHandler: Handler? = null
-
     }
-    //    private BluetoothSocket socket = null;
-
 }

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseFragment.kt
@@ -2,6 +2,7 @@ package io.treehouses.remote.bases
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
 import android.os.Handler
@@ -25,7 +26,7 @@ open class BaseFragment : Fragment() {
         super.onAttach(context)
         listener = if (context is HomeInteractListener) context else throw RuntimeException("Implement interface first")
         mChatService = listener.getChatService()
-        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        mBluetoothAdapter = (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
     }
 
     fun isListenerInitialized() = ::listener.isInitialized
@@ -39,7 +40,7 @@ open class BaseFragment : Fragment() {
     protected fun onLoad(mHandler: Handler?) {
 //        mChatService = listener.getChatService()
         mChatService.updateHandler(mHandler!!)
-        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        mBluetoothAdapter = (context?.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
 
         // If the adapter is null, then Bluetooth is not supported
         if (mBluetoothAdapter == null) {

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/dialogfragments/RPIDialogFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/dialogfragments/RPIDialogFragment.kt
@@ -5,6 +5,7 @@ import android.app.Dialog
 import android.app.ProgressDialog
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
 import android.content.*
 import android.os.Bundle
 import android.view.ContextThemeWrapper
@@ -43,7 +44,8 @@ class RPIDialogFragment : BaseDialogFragment(), DeviceDeleteListener {
     private var bind: ActivityRpiDialogFragmentBinding? = null
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         instance = this
-        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        val bluetoothManager = context?.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        mBluetoothAdapter = bluetoothManager?.adapter
         bluetoothCheck()
         if (mBluetoothAdapter!!.isDiscovering) mBluetoothAdapter!!.cancelDiscovery()
         mBluetoothAdapter!!.startDiscovery()

--- a/app/src/main/kotlin/io/treehouses/remote/network/BluetoothChatService.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/network/BluetoothChatService.kt
@@ -264,7 +264,7 @@ class BluetoothChatService @JvmOverloads constructor(handler: Handler? = null, a
             name = "ConnectThread$mSocketType"
             this@BluetoothChatService.state = Constants.STATE_CONNECTING
             // Always cancel discovery because it will slow down a connection
-            mAdapter.cancelDiscovery()
+            mAdapter?.cancelDiscovery()
 
             // Make a connection to the BluetoothSocket
             try {


### PR DESCRIPTION
fixes #1860
`'getDefaultAdapter(): BluetoothAdapter!' is deprecated`. so bumping to use the BluetoothManager system service to get a BluetoothAdapter instance to prevent the null exception