### PR TITLE
actions: bump `com.android.tools.build:gradle` to 8.2.2 (fixes #1866)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig true
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,5 @@ org.gradle.parallel=true
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Feb 12 14:25:18 EAT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.1.1 to 8.2.2.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-minor ...