### PR TITLE
actions: bump `dogi/sign-android-release` to 5 (fixes #1884)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,7 +57,7 @@ jobs:
           ls -al sign
 
       - name: sign release APK and AAB
-        uses: dogi/sign-android-release@v4.0.1
+        uses: dogi/sign-android-release@v5
         with:
           releaseDirectory: sign
           signingKeyBase64: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
#1884