### PR TITLE
actions: less warnings is more (fixes #1960)

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/adapter/ProfilesListAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/ProfilesListAdapter.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.BaseExpandableListAdapter
 import android.widget.Button
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import io.treehouses.remote.R
 import io.treehouses.remote.pojo.NetworkProfile
 import io.treehouses.remote.utils.SaveUtils.deleteProfile
@@ -46,7 +47,7 @@ class ProfilesListAdapter(private val context: Context, private val titles: List
     }
 
     override fun getGroupView(groupPosition: Int, isExpanded: Boolean, convertView: View?, parent: ViewGroup): View {
-        var newView: View
+        val newView: View
         val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
         newView = layoutInflater.inflate(R.layout.list_group, null)
         val label = newView.findViewById<TextView>(R.id.lblListHeader)
@@ -60,12 +61,13 @@ class ProfilesListAdapter(private val context: Context, private val titles: List
 
     private fun setLabelText(label: TextView, s: String, delete: Button) {
         label.text = s
-        label.setTextColor(context.resources.getColor(R.color.expandable_child_text))
+        label.setTextColor(ContextCompat.getColor(context, R.color.expandable_child_text))
+
         delete.visibility = View.GONE
     }
 
     override fun getChildView(groupPosition: Int, childPosition: Int, isLastChild: Boolean, convertView: View?, parent: ViewGroup): View {
-        var newView: View?
+        val newView: View?
         val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
         newView = layoutInflater.inflate(R.layout.row_profile, null)
         val label = newView.findViewById<TextView>(R.id.label)

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/ServicesListAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/ServicesListAdapter.kt
@@ -8,6 +8,7 @@ import android.widget.ArrayAdapter
 import android.widget.Filter
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import io.treehouses.remote.R
 import io.treehouses.remote.pojo.ServiceInfo
 import io.treehouses.remote.utils.logE
@@ -43,8 +44,7 @@ class ServicesListAdapter //private Button start, install, restart, link, info;
 
 
     override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
-        val view = initView(position, parent)
-        return view
+        return initView(position, parent)
     }
 
     override fun isEnabled(position: Int): Boolean {
@@ -75,8 +75,8 @@ class ServicesListAdapter //private Button start, install, restart, link, info;
                     drawable = R.drawable.circle_green
                 }
             }
-            name!!.setTextColor(context.resources.getColor(color))
-            status!!.setImageDrawable(context.resources.getDrawable(drawable))
+            name!!.setTextColor(ContextCompat.getColor(context, color))
+            status!!.setImageDrawable(ContextCompat.getDrawable(context, drawable))
         }
 
     }

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/ServicesListAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/ServicesListAdapter.kt
@@ -130,10 +130,10 @@ class ServicesListAdapter //private Button start, install, restart, link, info;
     private fun createFilteredList(constraint: CharSequence): List<ServiceInfo> {
         if (constraint.isEmpty()) return dataIn
         return dataIn.filter {
-            return@filter when (constraint.toString().toLowerCase(Locale.ROOT)) {
+            return@filter when (constraint.toString().lowercase(Locale.ROOT)) {
                 "installed" -> it.serviceStatus == ServiceInfo.SERVICE_INSTALLED
                 "available" -> it.serviceStatus == ServiceInfo.SERVICE_AVAILABLE
-                else -> it.name.toLowerCase(Locale.ROOT).contains(constraint.toString().toLowerCase(Locale.ROOT)) && !it.isHeader
+                else -> it.name.lowercase(Locale.ROOT).contains(constraint.toString().lowercase(Locale.ROOT)) && !it.isHeader
             }
         }
     }

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/SystemListAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/SystemListAdapter.kt
@@ -17,7 +17,7 @@ import io.treehouses.remote.utils.logD
 
 class SystemListAdapter(val context: Context, list: List<NetworkListItem>) : BaseExpandableListAdapter() {
     private val list: List<NetworkListItem>
-    private val inflater: LayoutInflater
+    private val inflater: LayoutInflater = LayoutInflater.from(context)
     private var listener: HomeInteractListener? = null
     private val views: MutableList<View>
     private val groupHeader: MutableList<View>
@@ -60,11 +60,10 @@ class SystemListAdapter(val context: Context, list: List<NetworkListItem>) : Bas
         return false
     }
 
-    override fun getGroupView(i: Int, b: Boolean, convertView: View?, parent: ViewGroup): View {
-        val newView: View?
-        newView = inflater.inflate(R.layout.list_group, parent, false)
-        val listHeader = newView.findViewById<TextView>(R.id.lblListHeader)
-        listHeader.text = getGroup(i).toString()
+    override fun getGroupView(i: Int, b: Boolean, convertView: View?, parent: ViewGroup): View? {
+        val newView = inflater.inflate(R.layout.list_group, parent, false)
+        val listHeader = newView?.findViewById<TextView>(R.id.lblListHeader)
+        listHeader?.text = getGroup(i).toString()
         groupHeader.add(newView)
         return newView
     }
@@ -104,7 +103,6 @@ class SystemListAdapter(val context: Context, list: List<NetworkListItem>) : Bas
     }
 
     init {
-        inflater = LayoutInflater.from(context)
         this.list = list
         views = mutableListOf()
         groupHeader = mutableListOf()

--- a/app/src/main/kotlin/io/treehouses/remote/adapter/TunnelPortAdapter.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/adapter/TunnelPortAdapter.kt
@@ -12,7 +12,7 @@ import io.treehouses.remote.R
 class TunnelPortAdapter(private val mContext: Context, private val data: List<String?>) : ArrayAdapter<String?>(mContext, 0, data) {
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
 
-        var convertedView: View
+        val convertedView: View
         val deleteAllPortsButtonSelected = data.size > 1 && position == data.size-1
         convertedView = if (deleteAllPortsButtonSelected) LayoutInflater.from(mContext).inflate(R.layout.select_dialog_item_delete_all, parent, false)
         else LayoutInflater.from(mContext).inflate(R.layout.select_dialog_item, parent, false)

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTerminalBridge.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTerminalBridge.kt
@@ -200,7 +200,7 @@ open class BaseTerminalBridge : VDUDisplay {
         // set underlined attributes if requested
         var newAddr = addr
         defaultPaint.isUnderlineText = currAttr and VDUBuffer.UNDERLINE != 0L
-        var isWideCharacter = currAttr and VDUBuffer.FULLWIDTH != 0L
+        val isWideCharacter = currAttr and VDUBuffer.FULLWIDTH != 0L
         if (isWideCharacter) newAddr++ else {
             // determine the amount of continuous characters with the same settings and print them all at once
             while (c + newAddr < vDUBuffer!!.columns
@@ -247,14 +247,14 @@ open class BaseTerminalBridge : VDUDisplay {
             var addr = 0
             val currAttr = vDUBuffer!!.charAttributes!![vDUBuffer!!.windowBase + l][c]
             run {
-                var (newFg, newBg) = setColors(currAttr)
+                val (newFg, newBg) = setColors(currAttr)
                 fg = newFg; bg = newBg
             }
 
-            var (newBg, newFg) = checkAndSwap(currAttr, bg, fg)
+            val (newBg, newFg) = checkAndSwap(currAttr, bg, fg)
             bg = newBg; fg = newFg
 
-            var (newAddr, newIsWideCharacter) = setAttributes(c, addr, l, currAttr)
+            val (newAddr, newIsWideCharacter) = setAttributes(c, addr, l, currAttr)
             addr = newAddr; isWideCharacter = newIsWideCharacter
             // Save the current clip region
             canvas.save()

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseTerminalFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseTerminalFragment.kt
@@ -10,6 +10,7 @@ import android.text.TextWatcher
 import android.view.View
 import android.widget.*
 import android.widget.AdapterView.OnItemClickListener
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
@@ -72,7 +73,7 @@ open class BaseTerminalFragment : BaseFragment() {
 
     fun getViews(view: View, isRead: Boolean): View {
         val consoleView = view.findViewById<TextView>(R.id.listItem)
-        if (isRead) { consoleView.setTextColor(resources.getColor(R.color.terminal))
+        if (isRead) { consoleView.setTextColor(ContextCompat.getColor(requireContext(), R.color.terminal))
         } else { consoleView.setTextColor(Color.RED) }
         return view
     }

--- a/app/src/main/kotlin/io/treehouses/remote/bases/FullScreenDialogFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/FullScreenDialogFragment.kt
@@ -5,10 +5,6 @@ import android.os.Bundle
 import android.view.ViewGroup
 
 open class FullScreenDialogFragment : BaseDialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog: Dialog = super.onCreateDialog(savedInstanceState)
-        return dialog
-    }
 
     override fun onStart() {
         super.onStart()

--- a/app/src/main/kotlin/io/treehouses/remote/fragments/DiscoverFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/DiscoverFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import com.parse.Parse.getApplicationContext
 import io.treehouses.remote.Constants
 import io.treehouses.remote.R
@@ -113,7 +114,7 @@ class DiscoverFragment : BaseFragment(), FragmentDialogInterface {
         val canvas = Canvas(bitmap)
         val p4 = Paint()
         p4.isAntiAlias = true
-        p4.color = resources.getColor(R.color.daynight_textColor)
+        p4.color = ContextCompat.getColor(requireContext(), R.color.daynight_textColor)
         p4.strokeWidth = 10f
         canvas.drawLine(startX, startY, endX, endY, p4)
 
@@ -142,7 +143,7 @@ class DiscoverFragment : BaseFragment(), FragmentDialogInterface {
     }
 
     private fun addDevices(readMessage: String): Boolean {
-        var regex = "([0-9]+\\.){3}[0-9]+\\s+([0-9A-Z]+:){5}[0-9A-Z]+".toRegex()
+        val regex = "([0-9]+\\.){3}[0-9]+\\s+([0-9A-Z]+:){5}[0-9A-Z]+".toRegex()
         val devices = regex.findAll(readMessage)
 
         devices.forEach {

--- a/app/src/main/kotlin/io/treehouses/remote/interfaces/FragmentDialogInterface.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/interfaces/FragmentDialogInterface.kt
@@ -15,13 +15,10 @@ interface FragmentDialogInterface {
         alertDialog.show()
     }
 
-    fun createAlertDialog(context: Context?, id:Int, title:String, message:String): AlertDialog.Builder {
-        val alertDialog = AlertDialog.Builder(ContextThemeWrapper(context, id))
-                .setTitle(title)
-                .setMessage(message)
-
-        return alertDialog
-
+    fun createAlertDialog(context: Context?, id: Int, title: String, message: String): AlertDialog.Builder {
+        return AlertDialog.Builder(ContextThemeWrapper(context, id))
+            .setTitle(title)
+            .setMessage(message)
     }
 
     fun createAlertDialog(ctw:ContextThemeWrapper, view: View?, title:Int, icon:Int):AlertDialog.Builder{

--- a/app/src/main/kotlin/io/treehouses/remote/ssh/SSH.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ssh/SSH.kt
@@ -83,7 +83,7 @@ class SSH: BaseSSH {
      */
 //    @Throws(NoSuchAlgorithmException::class, InvalidKeySpecException::class, IOException::class)
     private fun tryPublicKey(pubkey: PubKeyBean): Boolean {
-        var pair: KeyPair?
+        val pair: KeyPair?
 
         if (manager!!.loadedKeypairs.containsKey(pubkey.nickname)) {
             // load this key from memory if its already there
@@ -103,8 +103,7 @@ class SSH: BaseSSH {
                 if (password == null) return false
             }
             // load using internal generated format
-            val privKey: PrivateKey
-            privKey = try {
+            val privKey: PrivateKey = try {
                 PubKeyUtils.decodePrivate(pubkey.privateKey!!, pubkey.type, password)
             } catch (e: Exception) {
                 return onBadPassword(pubkey, e)

--- a/app/src/main/kotlin/io/treehouses/remote/sshconsole/BaseSSHConsole.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/sshconsole/BaseSSHConsole.kt
@@ -110,7 +110,7 @@ open class BaseSSHConsole: RootSSHConsole() {
     protected fun onEmulatedKeyClicked(v: View) {
         val terminal = adapter!!.currentTerminalView ?: return
         val handler = terminal.bridge.keyHandler
-        var hideKeys = sendKeys(v, handler)
+        val hideKeys = sendKeys(v, handler)
         if (hideKeys) hideEmulatedKeys()
         else autoHideEmulatedKeys()
 

--- a/app/src/main/kotlin/io/treehouses/remote/sshconsole/SSHConsole.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/sshconsole/SSHConsole.kt
@@ -152,7 +152,7 @@ open class SSHConsole : DerivedSSHConsole(), BridgeDisconnectedListener {
         super.onCreateOptionsMenu(menu)
         val view = adapter!!.currentTerminalView
         val activeTerminal = view != null
-        var (sessionOpen, disconnected) = checkSession(view, activeTerminal)
+        val (sessionOpen, disconnected) = checkSession(view, activeTerminal)
         menu.setQwertyMode(true)
         disconnect = menu.add("Disconnect")
         if (hardKeyboard) disconnect!!.alphabeticShortcut = 'w'
@@ -178,7 +178,7 @@ open class SSHConsole : DerivedSSHConsole(), BridgeDisconnectedListener {
         volumeControlStream = AudioManager.STREAM_NOTIFICATION
         val view = adapter?.currentTerminalView
         val activeTerminal = view != null
-        var (sessionOpen, disconnected) = checkSession(view, activeTerminal)
+        val (sessionOpen, disconnected) = checkSession(view, activeTerminal)
         disconnect?.isEnabled = activeTerminal
         if (sessionOpen || !disconnected) disconnect?.title = "Disconnect" else disconnect?.title = "Close Console"
         paste?.isEnabled = activeTerminal

--- a/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/home/HomeViewModel.kt
@@ -97,7 +97,7 @@ class HomeViewModel(application: Application) : FragmentViewModel(application) {
                 checkVersionSent = true
                 sendMessage(getString(R.string.TREEHOUSES_REMOTE_VERSION, BuildConfig.VERSION_CODE))
             }
-            s == RESULTS.ERROR && !output.toLowerCase(Locale.ROOT).contains("error") -> {
+            s == RESULTS.ERROR && !output.lowercase(Locale.ROOT).contains("error") -> {
                 error.value = output
                 internetSent = false
             }

--- a/app/src/main/kotlin/io/treehouses/remote/ui/network/NetworkViewModel.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/network/NetworkViewModel.kt
@@ -143,8 +143,8 @@ class NetworkViewModel(application: Application) : BaseNetworkViewModel(applicat
     }
 
     fun getSubString(stringStart: String, output: String) : String {
-        var startIndex = output.indexOf(stringStart)
-        var endIndex = output.indexOf("/s", startIndex)
+        val startIndex = output.indexOf(stringStart)
+        val endIndex = output.indexOf("/s", startIndex)
         return output.substring(startIndex, endIndex + 2)
     }
 

--- a/app/src/main/kotlin/io/treehouses/remote/ui/services/ServicesDetailsFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/services/ServicesDetailsFragment.kt
@@ -31,7 +31,7 @@ class ServicesDetailsFragment : BaseServicesDetailsFragment() {
 
         viewModel.servicesData.observe(viewLifecycleOwner, Observer {
             if (it.status == Status.SUCCESS) {
-                spinnerAdapter = ServicesListAdapter(requireContext(), viewModel.formattedServices, resources.getColor(R.color.md_grey_600))
+                spinnerAdapter = ServicesListAdapter(requireContext(), viewModel.formattedServices, ContextCompat.getColor(requireContext(), R.color.md_grey_600))
                 serviceCardAdapter = ServiceCardAdapter(childFragmentManager, viewModel.formattedServices)
                 initialize()
                 goToSelected()

--- a/app/src/main/kotlin/io/treehouses/remote/ui/socks/SocksViewModel.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/socks/SocksViewModel.kt
@@ -46,7 +46,7 @@ class SocksViewModel(application: Application) : FragmentViewModel(application) 
             sendMessage("treehouses shadowsocks list")
         } else if (readMessage.contains("tmptmp") && !readMessage.contains("disabled") && !readMessage.contains("stopped")) {
             if (readMessage.contains(' ')) {
-                var msgList = readMessage.split(' ')
+                val msgList = readMessage.split(' ')
                 msgList.forEach {
                     if (it.trim().startsWith("tmptmp") && !profileNameText.contains(it)) {
                         profileNameText.add(it)

--- a/app/src/main/kotlin/io/treehouses/remote/ui/status/StatusViewModel.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/ui/status/StatusViewModel.kt
@@ -93,8 +93,8 @@ class StatusViewModel(application: Application) : FragmentViewModel(application)
         try { if (lastCommand == getString(R.string.TREEHOUSES_REMOTE_STATUSPAGE)) {
                 val statusData = Gson().fromJson(output, StatusData::class.java)
                 temperature.value = statusData.temperature
-                var usedMemory = statusData.memory_used.trim { it <= ' ' }.toDouble()
-                var totalMemory = statusData.memory_total.trim { it <= ' ' }.toDouble()
+                val usedMemory = statusData.memory_used.trim { it <= ' ' }.toDouble()
+                val totalMemory = statusData.memory_total.trim { it <= ' ' }.toDouble()
                 storageBarValue.value = statusData.storage.split(" ")[3].dropLast(1).toInt()
                 storage.value = statusData.storage.split(" ")[2].dropLast(1).replace("G", "GB")
                 cpuModelText.value = "CPU: ARM " + statusData.arm
@@ -206,7 +206,7 @@ class StatusViewModel(application: Application) : FragmentViewModel(application)
     }
 
     fun onSelectCountry(selectedString: String) {
-        var selected = selectedString.substring(selectedString.length - 4, selectedString.length - 2)
+        val selected = selectedString.substring(selectedString.length - 4, selectedString.length - 2)
         sendMessage(getString(R.string.TREEHOUSES_WIFI_COUNTRY, selected))
         countryDisplayTextEnabled.value = false
         countryDisplayText.value = "Changing country"

--- a/app/src/main/kotlin/io/treehouses/remote/utils/CommandManager.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/utils/CommandManager.kt
@@ -65,7 +65,7 @@ class Output (val output: String) {
 }
 //Could remove IDs and simply use these functions
 object Matcher {
-    fun toLC(string: String) : String {return string.toLowerCase(Locale.ROOT).trim(); }
+    fun toLC(string: String) : String {return string.lowercase(Locale.ROOT).trim(); }
 
     fun isError(output: String): Boolean {
         val keys = listOf("error ", "unknown command", "usage: ", "not a valid option", "error: ", "not found")

--- a/app/src/main/kotlin/io/treehouses/remote/utils/TunnelSSHCommandManager.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/utils/TunnelSSHCommandManager.kt
@@ -51,7 +51,7 @@ object TunnelSSHMatcher {
     }
 
     fun checkNoTunnelSetup(output: String): Boolean {
-        return output.toLowerCase(Locale.ROOT).trim().contains("no tunnel has been set up")
+        return output.lowercase(Locale.ROOT).trim().contains("no tunnel has been set up")
     }
 
     fun isListModified(output: String): Boolean {


### PR DESCRIPTION
fixes #1960
this pr

1. declares unmodified variables using 'val'
2. inlines variable used only in following return
3. Use lowercase() instead of toLowerCase(Locale)
4. resolve deprecated 'getColor(Int): Int'