### PR TITLE
actions: smoother workflows keystore path (fixes #2176)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: prepare debug keystore directory
+        run: |
+          mkdir -p $HOME/.android
+          echo "ANDROID_SDK_HOME=$HOME" >> $GITHUB_ENV
       - name: setup JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -24,6 +24,11 @@ jobs:
       - name: checkout repository code
         uses: actions/checkout@v4
 
+      - name: prepare debug keystore directory
+        run: |
+          mkdir -p $HOME/.android
+          echo "ANDROID_SDK_HOME=$HOME" >> $GITHUB_ENV
+
       - name: setup JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary
- ensure a writable debug keystore path when building in CI

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_686db08afd2c832b9f8fc26fe3d1f910