### PR TITLE
Fix Bluetooth scanning permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ We assume you've already installed [Android Studio](https://developer.android.co
 
 1. In the android bluetooth settings, scan and pair with the Pi device (look for `treehouses`)
 
-2. Open the `treehouses remote` app 
+2. Open the `treehouses remote` app
+
+    Ensure that Bluetooth and location permissions are granted when prompted. Location access is required for Bluetooth scanning on modern Android versions.
 
 3. Click on "Connect to RPI"  
 

--- a/app/src/main/kotlin/io/treehouses/remote/bases/PermissionActivity.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/PermissionActivity.kt
@@ -38,7 +38,7 @@ abstract class PermissionActivity : AppCompatActivity() {
     }
 
     fun requestPermission() {
-        proceedWithoutLocationPermission()
+        proceedWithLocationPermission()
     }
 
     private fun proceedWithLocationPermission() {


### PR DESCRIPTION
## Summary
- request location access when asking for Bluetooth permissions
- mention permission requirement in the README

## Testing
- `./gradlew assembleDebug` *(fails: environment missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68703a0285a0832b93ce5cf1f656235c