### PR TITLE
fix(community): load the MIT remote map over https

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/fragments/CommunityFragment.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/fragments/CommunityFragment.kt
@@ -31,7 +31,7 @@ class CommunityFragment : BaseFragment(), BackPressReceiver {
         }
         bind.map.settings.javaScriptEnabled = true
         //bind.map.loadUrl("https://www.google.com/maps/d/u/0/viewer?ll=11.88717970130264%2C10.93123241891862&z=4&mid=1rO3RmHQnrSNsBwB9skqHos970zI-ZVAA")
-        bind.map.loadUrl("http://maps.media.mit.edu/remote.html")
+        bind.map.loadUrl("https://maps.media.mit.edu/remote.html")
 
         startGPSService()
     }


### PR DESCRIPTION
Closes #2314.

`CommunityFragment` loads the community map WebView with a cleartext URL:

`bind.map.loadUrl("http://maps.media.mit.edu/remote.html")`


`maps.media.mit.edu` serves the same page over https, so the swap is a one-character change. Drops the cleartext leg of this load and the passive-observer on-path-injection surface that came with it. The app still keeps its global `usesCleartextTraffic="true"` for now, but that flag can eventually be dropped once every remaining cleartext call site is migrated too.

### Change

kotlin
`- bind.map.loadUrl("http://maps.media.mit.edu/remote.html")`
`+ bind.map.loadUrl("https://maps.media.mit.edu/remote.html")`
