### PR TITLE
Fix generateKey

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
@@ -98,18 +98,21 @@ private fun startKeyGen(name: String, algorithm: String, password: String, bitSi
                     dismiss()
                 }
             }
-        }
-    }
-}
-
-    private fun startKeyGenInBackground(name: String, algorithm: String, password: String, bitSize: Int) {
-        requireActivity().run {
-            GlobalScope.launch(Dispatchers.Default) {
+private fun startKeyGenInBackground(name: String, algorithm: String, password: String, bitSize: Int) {
+    requireActivity().run {
+        GlobalScope.launch(Dispatchers.Default) {
+            if (bitSize <= 1024) { // Check the key size is within the valid range for DSA
                 val key = generateKey(name, algorithm, password, bitSize)
                 if (isActive) KeyUtils.saveKey(applicationContext, key)
                 withContext(Dispatchers.Main) {
                     Toast.makeText(applicationContext, "Key Generation Complete: $name $algorithm-$bitSize-bit", Toast.LENGTH_LONG).show()
                 }
+            } else { // If the key size is not within the valid range, throw an exception
+                throw InvalidKeyException("Invalid key size for algorithm DSA")
+            }
+        }
+    }
+}
             }
         }
         dismiss()

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
@@ -71,30 +71,36 @@ open class BaseSSHKeyGen : FullScreenDialogFragment() {
         return validateBitSize(Integer.parseInt(intToParse), getSelectedAlgo())
     }
 
-    private fun startKeyGen(name: String, algorithm: String, password: String, bitSize: Int) {
-        bind.progressBar.visibility = View.VISIBLE
-        bind.generateKey.isEnabled = false
-        bind.keyNameInput.isEnabled = false
-        bind.keyTypeSpinner.isEnabled = false
-        bind.keyStrength.isEnabled = false
-        bind.strengthShow.isEnabled = false
-        bind.inBackground.isEnabled = false
-        bind.passwordInput.isEnabled = false
-
-        lifecycleScope.launch(Dispatchers.Default) {
-val key = generateKey(name, algorithm, password, bitSize)
-if (isActive) {
-    synchronized(key) {
-        withContext(Dispatchers.Main) {
-            KeyUtils.saveKey(requireContext(), key)
-            bind.progressBar.visibility = View.GONE
-            Toast.makeText(requireContext(), "Key Generation Complete: $name $algorithm-$bitSize-bit", Toast.LENGTH_LONG).show()
-            dismiss()
+private fun startKeyGen(name: String, algorithm: String, password: String, bitSize: Int) {
+    bind.progressBar.visibility = View.VISIBLE
+    bind.generateKey.isEnabled = false
+    bind.keyNameInput.isEnabled = false
+    bind.keyTypeSpinner.isEnabled = false
+    bind.keyStrength.isEnabled = false
+    bind.strengthShow.isEnabled = false
+    bind.inBackground.isEnabled = false
+    bind.passwordInput.isEnabled = false
+    
+    val keySize = if (algorithm == "DSA") {
+        1024 // DSA keys are only supported with a key size of 1024 bits
+    } else {
+        bitSize // use the specified key size for other algorithms
+    }
+    
+    lifecycleScope.launch(Dispatchers.Default) {
+        val key = generateKey(name, algorithm, password, keySize)
+        if (isActive) {
+            synchronized(key) {
+                withContext(Dispatchers.Main) {
+                    KeyUtils.saveKey(requireContext(), key)
+                    bind.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), "Key Generation Complete: $name $algorithm-$bitSize-bit", Toast.LENGTH_LONG).show()
+                    dismiss()
+                }
+            }
         }
     }
 }
-        }
-    }
 
     private fun startKeyGenInBackground(name: String, algorithm: String, password: String, bitSize: Int) {
         requireActivity().run {

--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
@@ -82,15 +82,17 @@ open class BaseSSHKeyGen : FullScreenDialogFragment() {
         bind.passwordInput.isEnabled = false
 
         lifecycleScope.launch(Dispatchers.Default) {
-            val key = generateKey(name, algorithm, password, bitSize)
-            if (isActive) {
-                withContext(Dispatchers.Main) {
-                    KeyUtils.saveKey(requireContext(), key)
-                    bind.progressBar.visibility = View.GONE
-                    Toast.makeText(requireContext(), "Key Generation Complete: $name $algorithm-$bitSize-bit", Toast.LENGTH_LONG).show()
-                    dismiss()
-                }
-            }
+val key = generateKey(name, algorithm, password, bitSize)
+if (isActive) {
+    synchronized(key) {
+        withContext(Dispatchers.Main) {
+            KeyUtils.saveKey(requireContext(), key)
+            bind.progressBar.visibility = View.GONE
+            Toast.makeText(requireContext(), "Key Generation Complete: $name $algorithm-$bitSize-bit", Toast.LENGTH_LONG).show()
+            dismiss()
+        }
+    }
+}
         }
     }
 


### PR DESCRIPTION
# Fix: `generateKey`

## Explanation

This bug occurs due to a mistake in the input parameters passed to the generateKey() method. The error message indicates that the provided key size is invalid for the DSA algorithm used. To

---

## Modified Method

| Property | Value |
|---|---|
| Method | `generateKey` |
| Class | `io.treehouses.remote.bases.BaseSSHKeyGen` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/io.treehouses.remote_6098.apk/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/io.treehouses.remote_6098.apk/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline