### PR TITLE
Fix generateKey

### DIFF
--- a/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
+++ b/app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt
@@ -107,16 +107,16 @@ open class BaseSSHKeyGen : FullScreenDialogFragment() {
         dismiss()
     }
 
-    private suspend fun generateKey(name: String, algorithm: String, password: String, bitSize: Int): PubKeyBean {
-        return suspendCoroutine {
-            val keyPair = KeyPairGenerator.getInstance(algorithm).apply {
-                initialize(bitSize)
-            }.generateKeyPair()
-            val key = PubKeyBean(name, algorithm, PubKeyUtils.getEncodedPrivate(keyPair.private, password), keyPair.public.encoded)
-            if (password.isNotEmpty()) key.isEncrypted = true
-            it.resume(key)
-        }
+private suspend fun generateKey(name: String, algorithm: String, password: String, bitSize: Int): PubKeyBean {
+    return suspendCoroutine {
+        val keyPair = KeyPairGenerator.getInstance(algorithm).apply {
+            initialize(if (algorithm.equals("DSA", ignoreCase = true)) 2048 else bitSize)
+        }.generateKeyPair()
+        val key = PubKeyBean(name, algorithm, PubKeyUtils.getEncodedPrivate(keyPair.private, password), keyPair.public.encoded)
+        if (password.isNotEmpty()) key.isEncrypted = true
+        it.resume(key)
     }
+}
 
 
     protected fun setStrength(strength: Int, updateText: Boolean = true) {


### PR DESCRIPTION

# Fix generateKey

**Repository:** `treehouses/remote`  
**Type:** Pull request

---

## Analysis context

| Property | Value |
|---|---|
| Method | `generateKey` |
| Class | `io.treehouses.remote.bases.BaseSSHKeyGen` |
| File | `app/src/main/kotlin/io/treehouses/remote/bases/BaseSSHKeyGen.kt` |
| Specification | `KeyPairGeneratorSpec` |
| Analysis tool | `ape` |

## Proposed change

The runtime error confirms that `initialize(bitSize)` rejected the selected DSA key size. When the requested algorithm is DSA, the method now initializes it with the supported 2048-bit size while leaving the caller-provided size unchanged for all other algorithms.

## Validation

- [x] Change limited to the related file
- [x] Manual review required
- [ ] Confirmed by a project maintainer

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.